### PR TITLE
chore: set up shadcn/ui config and update base styles from Figma design

### DIFF
--- a/components.json
+++ b/components.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "tailwind.config.ts",
+    "css": "src/styles/globals.css",
+    "baseColor": "gray",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,21 +9,26 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-tabs": "^1.1.12",
+    "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "next": "14.2.3",
     "react": "^18",
     "react-dom": "^18",
-    "next": "14.2.3"
+    "tailwind-merge": "^3.3.0",
+    "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
-    "typescript": "^5",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "postcss": "^8",
-    "tailwindcss": "^3.4.1",
     "eslint": "^8",
     "eslint-config-next": "14.2.3",
+    "postcss": "^8",
     "prettier": "^3.5.3",
-    "prettier-plugin-tailwindcss": "^0.6.11"
+    "prettier-plugin-tailwindcss": "^0.6.11",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5"
   }
 }

--- a/src/lib/utils/className.ts
+++ b/src/lib/utils/className.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,25 +2,46 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  --foreground-rgb: 0, 0, 0;
-  --background-rgb: 255, 255, 255;
-}
+@layer components {
+  .shadow-normal {
+    @apply shadow-[0px_0px_1px_0px_rgba(0,0,0,0.08)] shadow-[0px_0px_8px_0px_rgba(0,0,0,0.12)];
+  }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --foreground-rgb: 255, 255, 255;
-    --background-rgb: 0, 0, 0;
+  .shadow-emphasize {
+    @apply shadow-[0px_0px_1px_0px_rgba(0,0,0,0.08)] shadow-[0px_1px_4px_0px_rgba(0,0,0,0.08)] shadow-[0px_2px_8px_0px_rgba(0,0,0,0.12)];
+  }
+
+  .shadow-strong {
+    @apply shadow-[0px_0px_4px_0px_rgba(0,0,0,0.08)] shadow-[0px_4px_8px_0px_rgba(0,0,0,0.08)] shadow-[0px_6px_12px_0px_rgba(0,0,0,0.12)];
+  }
+
+  .shadow-heavy {
+    @apply shadow-[0px_0px_8px_0px_rgba(0,0,0,0.08)] shadow-[0px_16px_20px_0px_rgba(0,0,0,0.12)] shadow-[0px_8px_16px_0px_rgba(0,0,0,0.08)];
+  }
+
+  .image-modal .carousel {
+    @apply fixed inset-0 flex h-screen w-screen items-center;
   }
 }
 
-body {
-  color: rgb(var(--foreground-rgb));
-  background: rgb(var(--background-rgb));
+/* WebKit browsers */
+input[type="search"]::-webkit-search-cancel-button {
+  display: none;
 }
 
-@layer utilities {
-  .text-balance {
-    text-wrap: balance;
+/* Firefox */
+input[type="search"]::-moz-search-cancel-button {
+  display: none;
+}
+
+/* Edge */
+input[type="search"]::-ms-clear {
+  display: none;
+}
+
+/* shadcn용 radius 변경시 수정 */
+@layer base {
+  :root {
+    --radius: 0.5rem;
   }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,24 +1,197 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
-  content: [
-    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
-  ],
+  content: ["./src/components/**/*.{js,ts,jsx,tsx,mdx}", "./src/app/**/*.{js,ts,jsx,tsx,mdx}"],
   theme: {
+    fontSize: {
+      heading: ["36px", { lineHeight: "150%", letterSpacing: "-0.025em" }], // Heading 36px
+      title1: ["24px", { lineHeight: "150%", letterSpacing: "-0.025em" }], // Title1 24px
+      subtitle: ["20px", { lineHeight: "150%", letterSpacing: "-0.015em" }], // Subtitle 20px
+      title2: ["18px", { lineHeight: "150%", letterSpacing: "-0.015em" }], // Title2 18px
+      body1: ["15px", { lineHeight: "150%", letterSpacing: "0.010em" }], // Body1 15px
+      body2: ["15px", { lineHeight: "150%", letterSpacing: "0" }], // Body2 15px (For Galmuri)
+      caption: ["13px", { lineHeight: "150%", letterSpacing: "0" }], // Caption 13px
+      small: ["11px", { lineHeight: "150%", letterSpacing: "0" }] // Small1 11px
+    },
     extend: {
-      backgroundImage: {
-        "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
-        "gradient-conic":
-          "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
-      },
       fontFamily: {
         pretendard: ["var(--font-pretendard)"],
-        galmuri: ["var(--font-galmuri)"],
+        galmuri: ["var(--font-galmuri)"]
       },
-    },
+      colors: {
+        primary: {
+          default: "#845F4C", // Brown/700
+          light: "#BCA386", // Brown/400
+          strong: "#553428", // Brown/900
+          "50": "#FFF9F0",
+          "100": "#F4EBDC",
+          "200": "#D2C7B6",
+          "300": "#BEB29F",
+          "400": "#BCA386",
+          "500": "#A88A76",
+          "600": "#93705C",
+          "700": "#845F4C",
+          "800": "#6C4839",
+          "900": "#553428",
+          "950": "#3D241B"
+        },
+        secondary: {
+          default: "#CDD5AE", // SageGreen/500
+          light: "#E9F0DB" // SageGreen/100
+        },
+        status: {
+          success: "#00F050", // Green/600
+          danger: "#ED7373", // Red/400
+          warning: "#FFDA6B", // Yellow/300
+          info: "#71AAFE" // Blue/300
+        },
+        sageGreen: {
+          DEFAULT: "#CDD5AE", // SageGreen/500
+          "50": "#F7F9F3", // SageGreen/50
+          "100": "#E9F0DB", // SageGreen/100
+          "200": "#DDE4C7", // SageGreen/200
+          "300": "#D2DAB6", // SageGreen/300
+          "400": "#C9D1AA", // SageGreen/400
+          "500": "#CDD5AE", // SageGreen/500
+          "600": "#B4BF98", // SageGreen/600
+          "700": "#9AA57F", // SageGreen/700
+          "800": "#7F8C68", // SageGreen/800
+          "900": "#5A6248", // SageGreen/900
+          "950": "#39402F" // SageGreen/950
+        },
+        bg: {
+          "01": "#FFFFFF",
+          "02": "#FFF9F0", // Brown/50
+          "03": "#D2C7B6" // Brown/200
+        },
+        line: {
+          "01": "#F5F5F5",
+          "02": "#E8E8E8",
+          "03": "#D1D1D1",
+          "04": "#B8B8B8"
+        },
+        text: {
+          "01": "#FFFFFF",
+          "02": "#B8B8B8",
+          "03": "#6E6E6E",
+          "04": "#1A1A1A"
+        },
+        gray: {
+          "50": "#F5F5F5",
+          "100": "#E8E8E8",
+          "200": "#D1D1D1",
+          "300": "#B8B8B8",
+          "400": "#9E9E9E",
+          "500": "#878787",
+          "600": "#6E6E6E",
+          "700": "#575757",
+          "800": "#3D3D3D",
+          "900": "#242424",
+          "950": "#1A1A1A"
+        },
+        green: {
+          "100": "#F0FFF5",
+          "200": "#BDFFD3",
+          "300": "#8AFFB1",
+          "400": "#57FF8F",
+          "500": "#24FF6D",
+          "600": "#00F050",
+          "700": "#00BF40",
+          "800": "#008A2E",
+          "900": "#00571D",
+          "950": "#00240C"
+        },
+        red: {
+          "100": "#FEFAFA",
+          "200": "#F9CDCD",
+          "300": "#F3A0A0",
+          "400": "#ED7373",
+          "500": "#E74646",
+          "600": "#DF1D1D",
+          "700": "#B01717",
+          "800": "#831111",
+          "900": "#560B0B",
+          "950": "#290505"
+        },
+        yellow: {
+          "100": "#FFF4D1",
+          "200": "#FFE79E",
+          "300": "#FFDA6B",
+          "400": "#FFCD38",
+          "500": "#FFC107",
+          "600": "#D19D00",
+          "700": "#9E7700",
+          "800": "#6B5000",
+          "900": "#382A00",
+          "950": "#050400"
+        },
+        blue: {
+          "100": "#D7E7FF",
+          "200": "#A4C8FE",
+          "300": "#71AAFE",
+          "400": "#3F8CFD",
+          "500": "#0C6EFD",
+          "600": "#0257D4",
+          "700": "#0142A2",
+          "800": "#012E6F",
+          "900": "#01193D",
+          "950": "#00040A"
+        }
+      },
+      keyframes: {
+        fadeIn: {
+          from: { opacity: "0" },
+          to: { opacity: "1" }
+        },
+        fadeOut: {
+          from: { opacity: "1" },
+          to: { opacity: "0" }
+        },
+        scaleUp: {
+          from: { transform: "scale(0.95)" },
+          to: { transform: "scale(1)" }
+        },
+        scaleDown: {
+          from: { transform: "scale(1)" },
+          to: { transform: "scale(0.95)" }
+        },
+        slideIn: {
+          "0%": { transform: "translateY(100%)" },
+          "100%": { transform: "translateY(0)" }
+        },
+        slideOut: {
+          "0%": { transform: "translateY(0)" },
+          "100%": { transform: "translateY(100%)" }
+        },
+        gradient: {
+          "0%": { backgroundPosition: "0% 50%" },
+          "50%": { backgroundPosition: "100% 50%" },
+          "100%": { backgroundPosition: "0% 50%" }
+        }
+      },
+      animation: {
+        gradient: "gradient 4s linear infinite",
+        fadeIn: "fadeIn 0.3s ease-out",
+        fadeOut: "fadeOut 0.3s ease-out",
+        scaleUp: "scaleUp 0.3s ease-out",
+        scaleDown: "scaleDown 0.3s ease-out",
+        slideIn: "slideIn 0.3s ease-in-out",
+        slideOut: "slideOut 0.3s ease-in-out"
+      },
+      screens: {
+        lt: { max: "1200px" }, // 일반 노트북 크기
+        tb: { max: "768px" }, // 일반 타블렛 크기
+        mb: { max: "480px" }, // 가장 큰 폰 크기
+        mn: { max: "375px" } // 모바일 디자인 시안 크기
+      }
+    }
   },
-  plugins: [],
+  variants: {
+    extend: {
+      backgroundColor: ["checked"], // checked 상태에서 배경색 활성화
+      borderColor: ["checked"], // checked 상태에서 테두리색 활성화
+      textColor: ["checked"] // checked 상태에서 텍스트 색상 활성화
+    }
+  }
 };
 export default config;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -192,6 +192,7 @@ const config: Config = {
       borderColor: ["checked"], // checked 상태에서 테두리색 활성화
       textColor: ["checked"] // checked 상태에서 텍스트 색상 활성화
     }
-  }
+  },
+  plugins: [require("tailwindcss-animate")]
 };
 export default config;


### PR DESCRIPTION
## Title
chore: set up shadcn/ui config and update base styles from Figma design

## Purpose
- Set up UI system foundation based on the Figma design.  
- This includes Tailwind setup, global styles, and shadcn/ui for consistent component development.

## Changes
- Created `components.json` with base shadcn/ui config
- Updated `tailwind.config.ts` with custom colors (Brown, SageGreen)
- Added global styles to `globals.css` (font, transition, reset)
- Installed core dependencies: `clsx`, `class-variance-authority`, `tailwind-merge`, `@radix-ui/react-slot` etc.

## Optional
Handling both design and dev… taking a bit more time 🥺...