### PR TITLE
Feat/mypage

### DIFF
--- a/src/app/mypage/_components/SelectTab.tsx
+++ b/src/app/mypage/_components/SelectTab.tsx
@@ -1,13 +1,18 @@
 "use client";
 
 import { useState } from "react";
+import StyleSection from "./StyleSection";
 
 const SelectTab = () => {
   const [filter, setFilter] = useState<"tab1" | "tab2">("tab1");
 
   const tabContents = {
     //Todo : add contents
-    tab1: <div className="flex w-full flex-col items-center justify-center pt-16">contents1</div>,
+    tab1: (
+      <div className="flex w-full flex-col items-center justify-center pt-16">
+        <StyleSection />
+      </div>
+    ),
     tab2: <div className="flex w-full flex-col items-center justify-center pt-16">contents2</div>
   };
 

--- a/src/app/mypage/_components/SelectTab.tsx
+++ b/src/app/mypage/_components/SelectTab.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useState } from "react";
+
+const SelectTab = () => {
+  const [filter, setFilter] = useState<"tab1" | "tab2">("tab1");
+
+  const tabContents = {
+    //Todo : add contents
+    tab1: <div className="flex w-full flex-col items-center justify-center pt-16">contents1</div>,
+    tab2: <div className="flex w-full flex-col items-center justify-center pt-16">contents2</div>
+  };
+
+  return (
+    <div className="mx-auto w-full max-w-[1000px]">
+      <div className="relative mx-auto flex max-w-[900px]">
+        {[
+          {
+            key: "tab1",
+            title: "꾸미기"
+          },
+          {
+            key: "tab2",
+            title: "컬렉션"
+          }
+        ].map((tab) => (
+          <button
+            key={tab.key}
+            onClick={() => setFilter(tab.key as "tab1" | "tab2")}
+            className={`flex-1 border-b py-2 text-center transition-colors ${
+              filter === tab.key
+                ? "border-primary-strong text-primary-strong"
+                : "border-primary-light text-primary-light"
+            }`}
+          >
+            <div className={`font-pretendard text-body1 ${filter === tab.key ? "font-bold" : ""}`}>{tab.title}</div>
+          </button>
+        ))}
+        <div
+          className="absolute bottom-0 h-[2px] bg-primary-strong transition-all duration-300"
+          style={{
+            width: "50%",
+            left: filter === "tab1" ? "0%" : "50%"
+          }}
+        />
+      </div>
+      {tabContents[filter]}
+    </div>
+  );
+};
+
+export default SelectTab;

--- a/src/app/mypage/_components/StyleSection.tsx
+++ b/src/app/mypage/_components/StyleSection.tsx
@@ -1,0 +1,35 @@
+import { Button } from "@/components/ui/Button";
+import Dropdown from "@/components/ui/Dropdown";
+import { ExportIcon } from "@phosphor-icons/react";
+
+const StyleSection = () => {
+  return (
+    <div className="flex w-full justify-center">
+      <div className="relative flex w-full flex-col gap-6 rounded-2xl bg-brown-100 px-12 py-12">
+        <div className="flex h-12 w-full flex-row items-start justify-end gap-[10px]">
+          <Dropdown
+            items={[{ label: "미니 모드" }, { label: "정원 모드", active: true }]}
+            className="font-pretendard text-body1 text-sageGreen-900"
+            mode="click"
+          />
+          <Button
+            variant="secondaryLine"
+            size="md"
+            className="shadow-normal flex items-center gap-2 text-body1"
+            onClick={() => {
+              navigator.clipboard.writeText(window.location.href);
+            }}
+          >
+            링크 복사하기
+            <ExportIcon width={20} height={20} />
+          </Button>
+        </div>
+
+        {/* Todo : separate contents for each mode */}
+        <div className="text-subtitle text-text-03">contents</div>
+      </div>
+    </div>
+  );
+};
+
+export default StyleSection;

--- a/src/app/mypage/_components/UserInfo.tsx
+++ b/src/app/mypage/_components/UserInfo.tsx
@@ -56,7 +56,7 @@ const UserInfo = () => {
                 onClick={() => setIsModalOpen(true)}
               >
                 더 보기
-                <CaretRightIcon className="h-4 w-4" weight="bold" />
+                <CaretRightIcon width={16} height={16} weight="bold" />
               </Button>
             </div>
             <div className="flex w-full flex-row gap-4">

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,12 +1,14 @@
 import ScrollTopButton from "@/components/shared/ScrollTopButton";
+import SelectTab from "./_components/SelectTab";
 import UserInfo from "./_components/UserInfo";
 
 const MyPage = () => {
   return (
     <>
       <div className="relative w-full bg-bg-03">
-        <div className="mx-auto flex min-h-screen w-full max-w-[1200px] flex-col items-start gap-60 px-8 pb-48 pt-32">
+        <div className="mx-auto flex min-h-screen w-full max-w-[1200px] flex-col items-start gap-16 px-8 pb-48 pt-20">
           <UserInfo />
+          <SelectTab />
         </div>
       </div>
       <ScrollTopButton />


### PR DESCRIPTION
## Title  
feat: add click mode to Dropdown, and apply new tabs and StyleSection in MyPage

## Purpose  
- Improve the reusability and flexibility of UI components  
- Implement MyPage layout according to the latest design guidelines (e.g. new tab and dropdown structure)

## Changes  
- **MyPage Layout**  
  - Created `SelectTab` and `StyleSection` components  
  - Applied the new components to the “Style” tab (the “Collection” tab will be added later)

- **Dropdown Enhancements**  
  - Added support for both `hover` and `click` modes to better match UI design requirements

- **Icon Consistency**  
  - Refactored icon components to accept `size` as a prop for better consistency and clarity across the UI