### PR TITLE
feat: add cloudinary domain to next/image config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,10 @@ const nextConfig = {
       {
         protocol: "http",
         hostname: "localhost"
+      },
+      {
+        protocol: "https",
+        hostname: "res.cloudinary.com"
       }
     ]
   }


### PR DESCRIPTION
## Title
feat: add cloudinary domain to next/image config

## Purpose
- Allow badge images from Cloudinary to render correctly in the frontend.

## Changes
- Added `res.cloudinary.com` to `images.remotePatterns` in `next.config.js`.
- Enabled Next.js to load external images from Cloudinary.