### PR TITLE
feat: apply next-intl for bilingual support

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1,0 +1,15 @@
+{
+  "common": {},
+  "navigation": {
+    "login": "Login",
+    "logout": "logout",
+    "mypage": "mypage"
+  },
+  "cta": {},
+  "mypage": {},
+  "plants-note": {
+    "title": "",
+    "plant": "",
+    "description": ""
+  }
+}

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1,0 +1,15 @@
+{
+  "common": {},
+  "navigation": {
+    "login": "로그인",
+    "logout": "로그아웃",
+    "mypage": "마이페이지"
+  },
+  "cta": {},
+  "mypage": {},
+  "plants-note": {
+    "title": "",
+    "plant": "",
+    "description": ""
+  }
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
+import createNextIntlPlugin from "next-intl/plugin";
+
+const withNextIntl = createNextIntlPlugin();
+
 const nextConfig = {
   images: {
     remotePatterns: [
@@ -15,7 +19,14 @@ const nextConfig = {
         hostname: "res.cloudinary.com"
       }
     ]
+  },
+  webpack: (config) => {
+    config.module.rules.push({
+      test: /\.json$/,
+      type: "json"
+    });
+    return config;
   }
 };
 
-export default nextConfig;
+export default withNextIntl(nextConfig);

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "next": "14.2.3",
+    "next-intl": "^4.1.0",
     "react": "^18",
     "react-dom": "^18",
     "swiper": "^11.2.8",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,8 @@ import Header from "@/components/layout/Header";
 import TQProviders from "@/lib/providers/TQProvider";
 import "@/lib/styles/globals.css";
 import type { Metadata } from "next";
+import { NextIntlClientProvider } from "next-intl";
+import { getLocale } from "next-intl/server";
 import localFont from "next/font/local";
 
 const pretendard = localFont({
@@ -23,18 +25,19 @@ export const metadata: Metadata = {
   description: "Generating plant visuals based on GitHub activity, designed for use in profile READMEs."
 };
 
-export default function RootLayout({
-  children
-}: Readonly<{
-  children: React.ReactNode;
-}>) {
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const locale = await getLocale();
+  const messages = (await import(`../../messages/${locale}.json`)).default;
+
   return (
-    <html lang="en" className={`${pretendard.variable} ${galmuri.variable}`}>
+    <html lang={locale} className={`${pretendard.variable} ${galmuri.variable}`}>
       <TQProviders>
         <body className={`${pretendard.className} ${galmuri.className} overflow-x-hidden`}>
-          <Header />
-          <main className="relative mx-auto w-full pt-20 tb:pt-0">{children}</main>
-          <Footer />
+          <NextIntlClientProvider locale={locale} messages={messages}>
+            <Header />
+            <main className="relative mx-auto w-full pt-20 tb:pt-0">{children}</main>
+            <Footer />
+          </NextIntlClientProvider>
         </body>
       </TQProviders>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
 
-export default function Home() {
+export default async function Home() {
   redirect("/home");
 }

--- a/src/components/layout/HeaderContent.tsx
+++ b/src/components/layout/HeaderContent.tsx
@@ -3,19 +3,32 @@
 import GithubIcon from "@/assets/icons/github";
 import StoreIcon from "@/assets/icons/store";
 import { useAuthStore } from "@/lib/store/authStore";
+import { useLanguageStore } from "@/lib/store/languageStore";
 import { GearSixIcon } from "@phosphor-icons/react";
+import { useTranslations } from "next-intl";
 import Link from "next/link";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import ProfileImageCircle from "../shared/ProfileImageCircle";
 import { Button } from "../ui/Button";
 import Dropdown from "../ui/Dropdown";
 
 const HeaderContent = () => {
   const { user, login, logout, checkAuth } = useAuthStore();
+  const { language, setLanguage } = useLanguageStore();
+  const t = useTranslations("navigation");
+  const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
     checkAuth();
+    setMounted(true);
   }, [checkAuth]);
+
+  const handleLanguageChange = (lang: string) => {
+    setLanguage(lang as "ko" | "en");
+  };
+
+  // 서버 사이드 렌더링 시에는 기본값 'ko'를 사용
+  const currentLanguage = mounted ? language : "ko";
 
   return (
     <header className="fixed left-0 top-0 z-50 w-full bg-white">
@@ -46,13 +59,16 @@ const HeaderContent = () => {
             >
               <div className="flex items-center gap-2">
                 <GithubIcon width={20} height={20} className="text-text-01" />
-                <span className="hidden text-body1 text-white md:flex">로그인</span>
+                <span className="hidden text-body1 text-white md:flex">{t("login")}</span>
               </div>
             </Button>
           )}
           {/* Language */}
           <Dropdown
-            items={[{ label: "English" }, { label: "한국어", active: true }]}
+            items={[
+              { label: "English", onClick: () => handleLanguageChange("en"), active: currentLanguage === "en" },
+              { label: "한국어", onClick: () => handleLanguageChange("ko"), active: currentLanguage === "ko" }
+            ]}
             className="font-galmuri text-body1"
             triggerClassName="h-[30px]"
           />
@@ -64,8 +80,8 @@ const HeaderContent = () => {
           {user && (
             <Dropdown
               items={[
-                { label: "마이페이지", onClick: () => (window.location.href = "/mypage") },
-                { label: "로그아웃", onClick: logout }
+                { label: t("mypage"), onClick: () => (window.location.href = "/mypage") },
+                { label: t("logout"), onClick: logout }
               ]}
               trigger={
                 <button className="flex h-[1.875rem] w-[1.875rem] items-center justify-center" aria-label="설정">

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,0 +1,12 @@
+import { getRequestConfig } from "next-intl/server";
+import { cookies } from "next/headers";
+
+export default getRequestConfig(async () => {
+  const cookieStore = cookies();
+  const locale = cookieStore.get("NEXT_LOCALE")?.value || "ko";
+
+  return {
+    locale,
+    messages: (await import(`../../messages/${locale}.json`)).default
+  };
+});

--- a/src/lib/store/languageStore.ts
+++ b/src/lib/store/languageStore.ts
@@ -1,0 +1,34 @@
+import { create } from "zustand";
+
+type Language = "ko" | "en";
+
+interface LanguageState {
+  language: Language;
+  setLanguage: (language: Language) => void;
+}
+
+// export language from cookie
+const getInitialLanguage = (): Language => {
+  if (typeof window === "undefined") {
+    // 서버 사이드에서는 기본값 'ko' 반환
+    return "ko";
+  }
+
+  // get language from cookie
+  const cookie = document.cookie.split("; ").find((row) => row.startsWith("NEXT_LOCALE="));
+  const savedLanguage = cookie?.split("=")[1] as Language;
+
+  // use saved language, if not, use default 'ko'
+  return savedLanguage || "ko";
+};
+
+export const useLanguageStore = create<LanguageState>((set) => ({
+  language: getInitialLanguage(),
+  setLanguage: (language) => {
+    // save language to cookie
+    document.cookie = `NEXT_LOCALE=${language}; path=/; max-age=31536000`;
+    set({ language });
+    // refresh page
+    window.location.reload();
+  }
+}));


### PR DESCRIPTION
## Title
feat: apply next-intl for bilingual support

## Purpose
- Set up bilingual service using `next-intl`, including language management and switch functionality.

## Changes
- Installed `next-intl` for handling translations  
- Configured `next-intl` with App Router (without i18n routing)  
- Created `.json` message files for multilingual content  
- Added language store with cookie persistence  
- Implemented language switcher in `Header`