### PR TITLE
feat: update components for bilingual support (1)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -11,5 +11,11 @@
     "title": "",
     "plant": "",
     "description": ""
+  },
+  "main-hero": {
+    "title": "Grow your own little friend,\nGit-Plants",
+    "subtitle": "Plant a commit, harvest a dream.\n(based on your GitHub activity)",
+    "startButton": "Get started",
+    "myPageButton": "Go to my page"
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -17,5 +17,13 @@
     "subtitle": "Plant a commit, harvest a dream.\n(based on your GitHub activity)",
     "startButton": "Get started",
     "myPageButton": "Go to my page"
+  },
+  "footer": {
+    "description": "Git-Plants is a personal project made for learning and portfolio purposes only.",
+    "feedback": "If you have any questions or feedback, feel free to drop an issue on",
+    "githubIssues": "GitHub Issues",
+    "feedbackEnd": ".",
+    "copyright": "",
+    "copyrightNotice": "© 2025 reizvoll. All illustrations and UI elements are copyright protected."
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -8,9 +8,17 @@
   "cta": {},
   "mypage": {},
   "plants-note": {
-    "title": "",
-    "plant": "",
-    "description": ""
+    "title": "Monthly Plant Note :",
+    "plant": "Corn",
+    "description": "Corn is the ultimate summer crop — it loves sunshine and \ngrows super fast when it’s warm. \nFrom June to August, it’s harvest time… and you know what \nthat means — it’s popcorn o’clock! 🍿🌽",
+    "growth_stage": {
+      "title": "Growth Stage",
+      "description": "Let’s explore \nthe 5 growth stages \n(from seed to harvest!)!"
+    },
+    "start_now": {
+      "title": "Start Now!",
+      "description": "Enjoy growing your plants, \nand don’t miss sweet rewards!"
+    }
   },
   "main-hero": {
     "title": "Grow your own little friend,\nGit-Plants",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -11,5 +11,11 @@
     "title": "",
     "plant": "",
     "description": ""
+  },
+  "main-hero": {
+    "title": "코드로 자라는 식물친구,\nGit-Plants",
+    "subtitle": "GitHub활동을 바탕으로 식물을 키우고, 씨앗을 수확해요!",
+    "startButton": "시작하기",
+    "myPageButton": "마이페이지"
   }
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -8,9 +8,17 @@
   "cta": {},
   "mypage": {},
   "plants-note": {
-    "title": "",
-    "plant": "",
-    "description": ""
+    "title": "이달의 식물노트:",
+    "plant": "옥수수(Corn)",
+    "description": "옥수수는 여름을 대표하는 대표적인 작물로.\n따뜻한 기후에서 잘 자라는 한해살이 식물입니다.\n주로 6월에서 8월 사이에 수확되며\n다양한 용도로 활용됩니다.(팝콘으로 제격이죠.)",
+    "growth_stage": {
+      "title": "성장 단계",
+      "description": "씨앗부터 수확까지,\n총 5단계의 성장 과정을\n함께 살펴봐요!"
+    },
+    "start_now": {
+      "title": "지금 시작해보세요!",
+      "description": "식물을 키우는 즐거움은 물론,\n쏠쏠한 보상도 함께 챙겨봐요!"
+    }
   },
   "main-hero": {
     "title": "코드로 자라는 식물친구,\nGit-Plants",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -17,5 +17,13 @@
     "subtitle": "GitHub활동을 바탕으로 식물을 키우고, 씨앗을 수확해요!",
     "startButton": "시작하기",
     "myPageButton": "마이페이지"
+  },
+  "footer": {
+    "description": "본 서비스는 개발자 포트폴리오 및 학습 목적의 비영리 프로젝트입니다.",
+    "feedback": "문의 및 피드백은",
+    "githubIssues": "GitHub Issues",
+    "feedbackEnd": "에 남겨주세요.",
+    "copyright": "창작물에 대한 무단 복제 및 상업적 사용을 금합니다.",
+    "copyrightNotice": "© 2025 reizvoll. All illustrations and UI elements are copyright protected."
   }
 }

--- a/src/app/home/_components/section/hero/MainHero.tsx
+++ b/src/app/home/_components/section/hero/MainHero.tsx
@@ -1,27 +1,24 @@
 import plant from "@/assets/images/plants.png";
 import { Button } from "@/components/ui/Button";
+import { useTranslations } from "next-intl";
 import Image from "next/image";
 
 const MainHero = () => {
+  const t = useTranslations("main-hero");
+
   return (
     <div className="shadow-emphasize flex items-center justify-center gap-16 rounded-[1rem] bg-[#F4EBDC]/80 px-16 py-16">
       <div className="flex w-full flex-col items-start gap-20">
         <div className="flex w-full flex-col items-start gap-12">
-          <div className="w-full font-galmuri text-heading text-primary-strong">
-            코드로 자라는 식물친구,
-            <br />
-            <span className="font-galmuri text-heading">Git-Plants</span>
-          </div>
-          <div className="font-galmuri text-title2 text-primary-strong">
-            GitHub활동을 바탕으로 식물을 키우고, 씨앗을 수확해요!
-          </div>
+          <div className="w-full whitespace-pre-line font-galmuri text-heading text-primary-default">{t("title")}</div>
+          <div className="text-subtitle2 whitespace-pre-line font-galmuri text-primary-default">{t("subtitle")}</div>
         </div>
         <div className="flex w-full flex-row items-start gap-4">
           <Button variant="primary" size="md" className="flex items-center justify-center px-8 py-3">
-            시작하기
+            {t("startButton")}
           </Button>
           <Button variant="primaryLine" size="md" className="flex items-center justify-center px-8 py-3">
-            마이페이지
+            {t("myPageButton")}
           </Button>
         </div>
       </div>

--- a/src/app/home/_components/section/note/NoteSection.tsx
+++ b/src/app/home/_components/section/note/NoteSection.tsx
@@ -2,36 +2,32 @@ import corn1 from "@/assets/images/corn1.webp";
 import corn2 from "@/assets/images/corn2.webp";
 import note from "@/assets/images/note.webp";
 import plant from "@/assets/images/plant_icon.png";
+import { useTranslations } from "next-intl";
 import Image from "next/image";
 
 //Todo : refactoring code, and explore strategies for connecting with the back office.
 const NoteSection = () => {
+  const t = useTranslations("plants-note");
   return (
     <div className="flex w-full justify-center">
       <div className="relative h-[634px] w-[1000px]">
         <Image src={note} alt="Note" className="object-cover" />
-        <div className="absolute inset-0 flex items-center justify-center px-12 py-12">
+        <div className="absolute inset-0 flex items-center justify-center px-12 py-20">
           <div className="flex w-full flex-row items-center justify-center gap-20">
             {/* Left Frame - Content Section */}
-            <div className="flex flex-col items-center justify-center gap-8">
+            <div className="flex flex-col items-center justify-center gap-6">
               {/* Section Title */}
-              <div className="flex flex-col items-center gap-4">
+              <div className="flex flex-col items-center gap-6">
                 {/* Heading */}
                 <div className="text-center font-galmuri text-title1 text-primary-strong">
-                  이달의 식물노트:
+                  {t("title")}
                   <br />
-                  옥수수(Corn)
+                  {t("plant")}
                 </div>
 
                 {/* Text */}
-                <div className="text-center font-galmuri text-title2 text-primary-strong">
-                  옥수수는 여름을 대표하는 대표적인 작물로.
-                  <br />
-                  따뜻한 기후에서 잘 자라는 한해살이 식물입니다.
-                  <br />
-                  주로 6월에서 8월 사이에 수확되며
-                  <br />
-                  다양한 용도로 활용됩니다.(팝콘으로 제격이죠.)
+                <div className="whitespace-pre-line text-center font-galmuri text-body2 text-primary-strong">
+                  {t("description")}
                 </div>
               </div>
 
@@ -42,7 +38,7 @@ const NoteSection = () => {
             </div>
 
             {/* Right Frame */}
-            <div className="flex flex-col items-center justify-center gap-20">
+            <div className="flex flex-col items-center justify-center gap-16">
               {/* Main Character Image */}
               <div className="h-[196px] w-[196px] rounded-full bg-bg-01">
                 <Image src={corn1} alt="corn" />
@@ -51,42 +47,36 @@ const NoteSection = () => {
               {/* Content */}
               <div className="flex flex-col items-center gap-4">
                 {/* Row */}
-                <div className="flex flex-row gap-6">
+                <div className="flex flex-row gap-8">
                   {/* First List Item */}
-                  <div className="flex flex-grow flex-col items-start gap-4">
+                  <div className="flex w-auto flex-grow flex-col items-start gap-4">
                     {/* Icon */}
                     <div className="h-[43px] w-12">
                       <Image src={plant} alt="icon" />
                     </div>
 
                     {/* Subheading */}
-                    <div className="font-pretendard text-title2 font-bold text-text-04">성장 단계</div>
+                    <div className="font-pretendard text-title2 font-bold text-text-04">{t("growth_stage.title")}</div>
 
                     {/* Text */}
-                    <p className="font-pretendard text-body1 text-text-04">
-                      씨앗부터 수확까지,
-                      <br />
-                      총 5단계의 성장 과정을
-                      <br />
-                      함께 살펴봐요!
+                    <p className="whitespace-pre-line font-pretendard text-caption text-text-04">
+                      {t("growth_stage.description")}
                     </p>
                   </div>
 
                   {/* Second List Item */}
-                  <div className="flex flex-grow flex-col items-start gap-4">
+                  <div className="flex w-auto flex-grow flex-col items-start gap-4">
                     {/* Icon */}
                     <div className="h-[43px] w-12">
                       <Image src={plant} alt="icon" />
                     </div>
 
                     {/* Subheading */}
-                    <div className="font-pretendard text-title2 font-bold text-text-04">지금 시작해보세요!</div>
+                    <div className="font-pretendard text-title2 font-bold text-text-04">{t("start_now.title")}</div>
 
                     {/* Text */}
-                    <p className="font-pretendard text-body1 text-text-04">
-                      식물을 키우는 즐거움은 물론,
-                      <br />
-                      쏠쏠한 보상도 함께 챙겨봐요!
+                    <p className="whitespace-pre-line font-pretendard text-caption text-text-04">
+                      {t("start_now.description")}
                     </p>
                   </div>
                 </div>

--- a/src/components/layout/FooterContent.tsx
+++ b/src/components/layout/FooterContent.tsx
@@ -1,33 +1,34 @@
 import GithubIcon from "@/assets/icons/github";
+import { useTranslations } from "next-intl";
 
 const FooterContent = () => {
+  const t = useTranslations("footer");
+
   return (
     <div className="flex h-52 w-full items-center bg-gray-700">
       <div className="mx-auto flex w-full max-w-[75rem] flex-col items-start justify-center gap-6 px-4 md:px-6 lg:px-8">
-        <div className="flex items-center gap-5">
+        <div className="flex items-center gap-4">
           <span className="text-subHeading text-text-04">Git-Plants</span>
-          <GithubIcon className="text-text-04" width={30} height={30} />
+          <GithubIcon className="text-text-04" width={28} height={28} />
         </div>
-        <div className="flex flex-col items-start gap-3">
-          <div className="font-pretendard text-body1 font-medium text-text-01">
-            본 서비스는 개발자 포트폴리오 및 학습 목적의 비영리 프로젝트입니다.
+        <div className="flex flex-col items-start gap-4">
+          <div className="font-pretendard text-caption font-medium text-text-01">
+            {t("description")}
             <br />
-            문의 및 피드백은
+            {t("feedback")}
             <a
               href="https://github.com/reizvoll/git-plants-frontend/issues"
               target="_blank"
               rel="noopener noreferrer"
               className="m-0.5 ml-1.5 underline"
             >
-              GitHub Issues
+              {t("githubIssues")}
             </a>
-            에 남겨주세요.
-            <br />
-            창작물에 대한 무단 복제 및 상업적 사용을 금합니다.
+            {t("feedbackEnd")}
+            &nbsp;
+            {t("copyright")}
           </div>
-          <div className="font-galmuri text-small text-text-01">
-            © 2025 reizvoll. All illustrations and UI elements are copyright protected.
-          </div>
+          <div className="font-galmuri text-caption text-text-01">{t("copyrightNotice")}</div>
         </div>
       </div>
     </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,6 +8,7 @@ const config: Config = {
       subHeading: ["28px", { lineHeight: "150%", letterSpacing: "-0.025em" }], // SubHeading 28px
       title1: ["24px", { lineHeight: "150%", letterSpacing: "-0.025em" }], // Title1 24px
       subtitle: ["20px", { lineHeight: "150%", letterSpacing: "-0.015em" }], // Subtitle 20px
+      subtitle2: ["20px", { lineHeight: "200%", letterSpacing: "-0.015em" }], // Subtitle2 20px (for hero subtitle)
       title2: ["18px", { lineHeight: "150%", letterSpacing: "-0.015em" }], // Title2 18px
       body1: ["15px", { lineHeight: "150%", letterSpacing: "0.010em" }], // Body1 15px
       body2: ["15px", { lineHeight: "150%", letterSpacing: "0" }], // Body2 15px (For Galmuri)


### PR DESCRIPTION
## Title
feat: update components for bilingual support (1)

## Purpose
- To add bilingual support to components like Hero, Footer, and plants-note using `next-intl`.

## Changes
- Updated messages and made `MainHero` component bilingual  
- Added `subtitle2` style to Tailwind theme for Hero's English subtitle  
- Updated messages and applied bilingual support to `Footer`  
- Added bilingual support to `plants-note` section