### PR TITLE
feat: update MyPage badge modal layout and add StyleSection features

### DIFF
--- a/src/app/mypage/_components/BadgeModal.tsx
+++ b/src/app/mypage/_components/BadgeModal.tsx
@@ -3,19 +3,19 @@ import badgeSlot from "@/assets/images/badge_slot.webp";
 import ModalItem from "@/components/ui/Modal";
 import Image from "next/image";
 
-interface Badge {
+type Badge = {
   id: string;
   badge: {
     imageUrl: string;
     name: string;
   };
-}
+};
 
-interface BadgeModalProps {
+type BadgeModalProps = {
   isOpen: boolean;
   onClose: () => void;
   badges: Badge[];
-}
+};
 
 const BadgeModal = ({ isOpen, onClose, badges }: BadgeModalProps) => {
   return (
@@ -23,8 +23,11 @@ const BadgeModal = ({ isOpen, onClose, badges }: BadgeModalProps) => {
       <div className="flex flex-col items-center gap-9">
         <div className="flex w-full items-center justify-between">
           <span className="text-subHeading text-text-01">뱃지 보관함</span>
-          <button onClick={onClose} className="text-heading text-text-01">
-            <Close width={36} height={36} />
+          <button onClick={onClose} className="relative p-2 text-heading text-text-01">
+            <div className="absolute inset-0 z-10" />
+            <div className="relative z-0">
+              <Close width={36} height={36} />
+            </div>
           </button>
         </div>
         <div className="relative">

--- a/src/app/mypage/_components/BadgeModal.tsx
+++ b/src/app/mypage/_components/BadgeModal.tsx
@@ -32,8 +32,8 @@ const BadgeModal = ({ isOpen, onClose, badges }: BadgeModalProps) => {
         </div>
         <div className="relative">
           <Image src={badgeSlot} alt="badgeSlot" priority />
-          <div className="absolute inset-0 flex -translate-x-3 -translate-y-[72px] transform flex-col items-center justify-center">
-            <div className="grid grid-cols-6 gap-6">
+          <div className="absolute inset-0 flex -translate-x-[3px] -translate-y-[72px] transform flex-col items-center justify-center">
+            <div className="grid grid-cols-6 gap-7">
               {badges.map((badge) => (
                 <div key={badge.id} className="group relative flex flex-col items-center">
                   <Image src={badge.badge.imageUrl} alt={badge.badge.name} width={120} height={120} />

--- a/src/app/mypage/_components/SizeAdjustModal.tsx
+++ b/src/app/mypage/_components/SizeAdjustModal.tsx
@@ -1,0 +1,104 @@
+import { Button } from "@/components/ui/Button";
+import ModalItem from "@/components/ui/Modal";
+import { useEffect, useState, type KeyboardEvent } from "react";
+
+interface SizeAdjustModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  currentSize: { width: number; height: number };
+  onApply: (size: { width: number; height: number }) => void;
+}
+
+const SizeAdjustModal = ({ isOpen, onClose, currentSize, onApply }: SizeAdjustModalProps) => {
+  const [tempSize, setTempSize] = useState(currentSize);
+
+  useEffect(() => {
+    setTempSize(currentSize);
+  }, [currentSize]);
+
+  useEffect(() => {
+    const handleGlobalKeyDown = (e: globalThis.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener("keydown", handleGlobalKeyDown);
+      return () => {
+        document.removeEventListener("keydown", handleGlobalKeyDown);
+      };
+    }
+  }, [isOpen, onClose]);
+
+  const handleApply = () => {
+    onApply(tempSize);
+    onClose();
+  };
+
+  const handleCancel = () => {
+    onClose();
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleApply();
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <ModalItem isOpen={isOpen} onClose={onClose} mode="default">
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleApply();
+        }}
+        onKeyDown={handleKeyDown}
+        tabIndex={-1}
+        className="flex flex-col gap-4"
+      >
+        <div className="font-pretendard text-subtitle font-bold text-text-04">사이즈 조정</div>
+        <div className="flex items-center justify-center gap-3">
+          <input
+            value={tempSize.width}
+            onChange={(e) => setTempSize((prev) => ({ ...prev, width: Number(e.target.value) }))}
+            onKeyDown={handleKeyDown}
+            className="rounded-lg bg-gray-50 px-3 py-4 text-center font-pretendard text-body1 text-text-04 outline-none"
+          />
+          <span className="font-pretendard text-title2 text-text-03">x</span>
+          <input
+            value={tempSize.height}
+            onChange={(e) => setTempSize((prev) => ({ ...prev, height: Number(e.target.value) }))}
+            onKeyDown={handleKeyDown}
+            className="rounded-lg bg-gray-50 px-3 py-4 text-center font-pretendard text-body1 text-text-04 outline-none"
+          />
+          <span className="font-pretendard text-title2 text-text-03">px</span>
+        </div>
+        <div className="text-center font-pretendard text-caption text-text-03">
+          모드에 따라 권장 비율이 달라요! 모드에 맞춰 비율을 설정해 보세요.
+          <br />
+          (미니모드: 2:3 /정원 모드: 4:3 or 16:9)
+        </div>
+        <div className="flex gap-3">
+          <Button type="submit" variant="primary" size="md" className="w-full text-body1 text-text-01">
+            적용하기
+          </Button>
+          <Button
+            type="button"
+            variant="disabled"
+            size="md"
+            className="w-full text-body1 text-text-03"
+            onClick={handleCancel}
+          >
+            취소하기
+          </Button>
+        </div>
+      </form>
+    </ModalItem>
+  );
+};
+
+export default SizeAdjustModal;

--- a/src/app/mypage/_components/StyleSection.tsx
+++ b/src/app/mypage/_components/StyleSection.tsx
@@ -1,14 +1,49 @@
 import { Button } from "@/components/ui/Button";
 import Dropdown from "@/components/ui/Dropdown";
-import { ExportIcon } from "@phosphor-icons/react";
+import { useProfileStore } from "@/lib/store/profileStore";
+import { ExportIcon, SlidersHorizontalIcon } from "@phosphor-icons/react";
+import Image from "next/image";
+import { useState } from "react";
 
 const StyleSection = () => {
+  const { equipped } = useProfileStore();
+  const [currentMode, setCurrentMode] = useState("GARDEN"); // 드롭다운 상태 추가
+
+  // 모드에 따른 기본 이미지 크기 설정
+  const getDefaultImageSize = (mode: string) => {
+    return mode === "MINI" ? { width: 267, height: 400 } : { width: 400, height: 200 };
+  };
+
+  const [imageSize, setImageSize] = useState(getDefaultImageSize("GARDEN"));
+
+  // 현재 모드에 따른 배경화면과 화분 필터링
+  const currentBackgrounds = equipped?.backgrounds?.filter((bg) => bg.mode === currentMode) || [];
+  const currentPots = equipped?.pots?.filter((pot) => pot.mode === currentMode) || [];
+
+  const handleModeChange = (selectedMode: string) => {
+    const newMode = selectedMode === "미니 모드" ? "MINI" : "GARDEN";
+    setCurrentMode(newMode);
+    // 모드 변경 시 해당 모드에 맞는 기본 크기로 설정
+    setImageSize(getDefaultImageSize(newMode));
+  };
+
   return (
     <div className="flex w-full justify-center">
       <div className="relative flex w-full flex-col gap-6 rounded-2xl bg-brown-100 px-12 py-12">
         <div className="flex h-12 w-full flex-row items-start justify-end gap-[10px]">
           <Dropdown
-            items={[{ label: "미니 모드" }, { label: "정원 모드", active: true }]}
+            items={[
+              {
+                label: "미니 모드",
+                onClick: () => handleModeChange("미니 모드"),
+                active: currentMode === "MINI"
+              },
+              {
+                label: "정원 모드",
+                onClick: () => handleModeChange("정원 모드"),
+                active: currentMode === "GARDEN"
+              }
+            ]}
             className="font-pretendard text-body1 text-sageGreen-900"
             mode="click"
           />
@@ -26,7 +61,85 @@ const StyleSection = () => {
         </div>
 
         {/* Todo : separate contents for each mode */}
-        <div className="text-subtitle text-text-03">contents</div>
+        <div className="flex flex-row gap-[60px]">
+          <div className="flex flex-col items-center gap-6">
+            {/* 현재 선택된 배경화면 표시 */}
+            <div className="flex flex-col items-center gap-2">
+              {currentBackgrounds.length > 0 ? (
+                <div className="relative">
+                  <Image
+                    src={currentBackgrounds[0].imageUrl}
+                    alt={currentBackgrounds[0].name}
+                    className="object-cover"
+                    width={imageSize.width}
+                    height={imageSize.height}
+                  />
+                </div>
+              ) : (
+                <div className="flex items-center justify-center bg-gray-200">
+                  <div className="text-body3 text-text-04">배경화면 없음</div>
+                </div>
+              )}
+            </div>
+            <div className="text-body2 text-text-03">
+              현재 사이즈 <br />
+              {currentBackgrounds.length > 0 && (
+                <span className="text-body3 text-text-03">
+                  {currentBackgrounds[0].imageUrl && (
+                    <>
+                      {imageSize.width} X {imageSize.height} px
+                    </>
+                  )}
+                </span>
+              )}
+            </div>
+            <Button
+              variant="primary"
+              size="md"
+              className="flex flex-row items-center gap-2 text-body1"
+              // onClick={} (TODO: 사이즈 조정 모달 생성 필요)
+            >
+              사이즈 조정하기
+              <SlidersHorizontalIcon width={16} height={16} />
+            </Button>
+          </div>
+          <div className="flex flex-col gap-[60px]">
+            <div className="flex flex-col gap-6">
+              <div className="text-body2 text-text-03">배경화면</div>
+              <div className="flex flex-wrap gap-4">
+                {currentBackgrounds.length > 0 ? (
+                  currentBackgrounds.map((background) => (
+                    <div key={background.id} className="relative">
+                      <Image
+                        src={background.iconUrl}
+                        alt={background.name}
+                        className="object-cover"
+                        width={80}
+                        height={80}
+                      />
+                    </div>
+                  ))
+                ) : (
+                  <div className="text-body3 text-text-04">배경화면이 없습니다</div>
+                )}
+              </div>
+            </div>
+            <div className="flex flex-col gap-4">
+              <div className="text-body2 text-text-03">화분</div>
+              <div className="flex flex-wrap gap-4">
+                {currentPots.length > 0 ? (
+                  currentPots.map((pot) => (
+                    <div key={pot.id} className="relative">
+                      <Image src={pot.iconUrl} alt={pot.name} className="object-cover" width={80} height={80} />
+                    </div>
+                  ))
+                ) : (
+                  <div className="text-body3 text-text-03">화분이 없습니다</div>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/app/mypage/_components/StyleSection.tsx
+++ b/src/app/mypage/_components/StyleSection.tsx
@@ -4,26 +4,25 @@ import { useProfileStore } from "@/lib/store/profileStore";
 import { ExportIcon, SlidersHorizontalIcon } from "@phosphor-icons/react";
 import Image from "next/image";
 import { useState } from "react";
+import SizeAdjustModal from "./SizeAdjustModal";
 
 const StyleSection = () => {
   const { equipped } = useProfileStore();
-  const [currentMode, setCurrentMode] = useState("GARDEN"); // 드롭다운 상태 추가
+  const [currentMode, setCurrentMode] = useState("GARDEN");
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
-  // 모드에 따른 기본 이미지 크기 설정
   const getDefaultImageSize = (mode: string) => {
-    return mode === "MINI" ? { width: 267, height: 400 } : { width: 400, height: 200 };
+    return mode === "MINI" ? { width: 267, height: 400 } : { width: 400, height: 300 };
   };
 
   const [imageSize, setImageSize] = useState(getDefaultImageSize("GARDEN"));
 
-  // 현재 모드에 따른 배경화면과 화분 필터링
   const currentBackgrounds = equipped?.backgrounds?.filter((bg) => bg.mode === currentMode) || [];
   const currentPots = equipped?.pots?.filter((pot) => pot.mode === currentMode) || [];
 
   const handleModeChange = (selectedMode: string) => {
     const newMode = selectedMode === "미니 모드" ? "MINI" : "GARDEN";
     setCurrentMode(newMode);
-    // 모드 변경 시 해당 모드에 맞는 기본 크기로 설정
     setImageSize(getDefaultImageSize(newMode));
   };
 
@@ -70,14 +69,17 @@ const StyleSection = () => {
                   <Image
                     src={currentBackgrounds[0].imageUrl}
                     alt={currentBackgrounds[0].name}
-                    className="object-cover"
+                    style={{
+                      width: `${imageSize.width}px`,
+                      height: `${imageSize.height}px`
+                    }}
                     width={imageSize.width}
                     height={imageSize.height}
                   />
                 </div>
               ) : (
                 <div className="flex items-center justify-center bg-gray-200">
-                  <div className="text-body3 text-text-04">배경화면 없음</div>
+                  <div className="text-body3 text-text-04">배경화면이 존재하지 않습니다.</div>
                 </div>
               )}
             </div>
@@ -97,7 +99,7 @@ const StyleSection = () => {
               variant="primary"
               size="md"
               className="flex flex-row items-center gap-2 text-body1"
-              // onClick={} (TODO: 사이즈 조정 모달 생성 필요)
+              onClick={() => setIsModalOpen(true)}
             >
               사이즈 조정하기
               <SlidersHorizontalIcon width={16} height={16} />
@@ -120,7 +122,7 @@ const StyleSection = () => {
                     </div>
                   ))
                 ) : (
-                  <div className="text-body3 text-text-04">배경화면이 없습니다</div>
+                  <div className="text-body3 text-text-04">배경화면이 없습니다.</div>
                 )}
               </div>
             </div>
@@ -134,13 +136,19 @@ const StyleSection = () => {
                     </div>
                   ))
                 ) : (
-                  <div className="text-body3 text-text-03">화분이 없습니다</div>
+                  <div className="text-body3 text-text-03">화분이 없습니다.</div>
                 )}
               </div>
             </div>
           </div>
         </div>
       </div>
+      <SizeAdjustModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        currentSize={imageSize}
+        onApply={setImageSize}
+      />
     </div>
   );
 };

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -15,7 +15,7 @@ const buttonVariants = cva(
         secondaryLine:
           "bg-bg-01 border border-sageGreen-900 !text-sageGreen-900 hover:bg-sageGreen-50 active:bg-sageGreen-700",
         secondaryStrong: "bg-sageGreen-700 !text-text-01 hover:bg-sageGreen-900",
-        disabled: "bg-bg-02 !text-text-02",
+        disabled: "bg-gray-50 !text-text-02",
         disabledLine: "bg-bg-01 border border-line-02 !text-text-02",
         gray: "bg-gray-800 !text-text-01 hover:bg-gray-700 active:bg-gray-600",
         grayLine: "bg-bg-01 border border-gray-500 !text-text-03 hover:bg-gray-50"

--- a/src/lib/store/profileStore.ts
+++ b/src/lib/store/profileStore.ts
@@ -7,8 +7,8 @@ export const useProfileStore = create<ProfileState>((set) => ({
   seedCount: 0,
   badges: [],
   equipped: {
-    background: null,
-    pot: null
+    backgrounds: [],
+    pots: []
   },
   plants: [],
   isLoading: false,

--- a/src/lib/types/profile.ts
+++ b/src/lib/types/profile.ts
@@ -14,7 +14,12 @@ export type Item = {
   name: string;
   category: string;
   imageUrl: string;
+  iconUrl: string;
   price: number;
+  mode: string;
+  createdAt: string;
+  updatedAt: string;
+  updatedById: string;
 };
 
 export type Plant = {
@@ -34,8 +39,8 @@ export interface ProfileState {
   seedCount: number;
   badges: Badge[];
   equipped: {
-    background: Item | null;
-    pot: Item | null;
+    backgrounds: Item[];
+    pots: Item[];
   };
   plants: Plant[];
   isLoading: boolean;


### PR DESCRIPTION
## Title  
feat: update MyPage badge modal layout and add StyleSection features

## Purpose  
- To display equipped items from the server and apply UI updates based on the Figma design.

## Changes  
- Fixed close button interaction in the badge modal  
- Adjusted badge modal layout so badges align correctly with the background  
- Supported multiple equipped items by updating `profileStore` and types  
- Added mode-based equipped item display (GARDEN / MINI)  
- Created `SizeAdjustModal` and applied it to `StyleSection`  
- Updated disabled button background color to `bg-gray-50`

## Optional  
- Still considering whether background size adjustments should be stored in the backend or remain client-only.