### PR TITLE
feat: support per-mode size customization and update UI layout in StyleSection

### DIFF
--- a/src/app/mypage/_components/StyleSection.tsx
+++ b/src/app/mypage/_components/StyleSection.tsx
@@ -112,15 +112,27 @@ const StyleSection = () => {
                 </span>
               )}
             </div>
-            <Button
-              variant="primary"
-              size="md"
-              className="flex flex-row items-center gap-2 text-body1"
-              onClick={() => setIsModalOpen(true)}
-            >
-              사이즈 조정하기
-              <SlidersHorizontalIcon width={16} height={16} />
-            </Button>
+            <div className={`flex ${currentMode === "MINI" ? "flex-col" : "flex-row"} gap-2`}>
+              <Button
+                variant="primary"
+                size="md"
+                className="flex flex-row items-center gap-2 text-body1"
+                onClick={() => setIsModalOpen(true)}
+              >
+                사이즈 조정하기
+                <SlidersHorizontalIcon width={16} height={16} />
+              </Button>
+              <Button
+                variant="primaryLine"
+                size="md"
+                className="flex flex-row items-center gap-2 text-body1"
+                onClick={() => {
+                  setCustomSizes({});
+                }}
+              >
+                기본값으로 설정하기
+              </Button>
+            </div>
           </div>
           <div className="flex flex-col gap-[60px]">
             <div className="flex flex-col gap-6">


### PR DESCRIPTION
## Title
feat: support per-mode size customization and update UI layout in StyleSection

## Purpose
- Avoid adding extra fields to the backend by managing size settings via `localStorage`.
- Provide a smoother UX by dynamically updating button layout depending on the selected mode (GARDEN / MINI).

## Changes
- Added localStorage logic for storing and retrieving per-mode size preferences
- Applied auto-save for size changes using `useEffect`
- Improved layout of size adjustment/reset buttons based on mode
- Cleaned up code and added English comments for clarity

## Optional  
- I’ve just joined a new project, so further development on this feature might be delayed for a bit.
  Hoping to come back and continue improving it soon!