### PR TITLE
chore: add missing type definitions for public API endpoints

### DIFF
--- a/src/lib/types/api/public.ts
+++ b/src/lib/types/api/public.ts
@@ -1,0 +1,34 @@
+export type MonthlyPlant = {
+  id: number;
+  title: string;
+  name: string;
+  description: string;
+  imageUrls: string[];
+  iconUrl: string;
+  month: number;
+  year: number;
+};
+
+export type UpdateNote = {
+  id: number;
+  title: string;
+  description: string;
+  imageUrl: string;
+};
+
+export type NewItem = {
+  id: number;
+  name: string;
+  description: string;
+  imageUrl: string;
+  type: "background" | "pot" | "decoration";
+  price?: number;
+};
+
+export type CurrentUpdate = {
+  month: number;
+  year: number;
+  plant: MonthlyPlant;
+  updateNote: UpdateNote;
+  newItems: NewItem[];
+};


### PR DESCRIPTION
## Title  
chore: add missing type definitions for public API endpoints

## Purpose  
- 15 min ago, I accidentally pushed the public API endpoints in the `feat/api` branch without type definitions.  
- This PR adds the missing types for `/monthly-plant` and `/current-update` to keep things clean and typed.

## Changes  
- Added `types/api/public.ts` to define response types for public-facing endpoints.

## Optional  
>  REMINDER - avoid committing after too many changes at once