### PR TITLE
feat: render plant using updated profile response and enable pot position adjustment

### DIFF
--- a/src/app/mypage/_components/PotPositionAdjustModal.tsx
+++ b/src/app/mypage/_components/PotPositionAdjustModal.tsx
@@ -1,0 +1,68 @@
+import Modal from "@/components/ui/Modal";
+
+interface PotPositionAdjustModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  currentPotPosition: { x: number; y: number };
+  onApply: (position: { x: number; y: number }) => void;
+  selectedPot?: {
+    id: number;
+    name: string;
+    iconUrl: string;
+  } | null;
+}
+
+const PotPositionAdjustModal = ({
+  isOpen,
+  onClose,
+  currentPotPosition,
+  onApply,
+  selectedPot
+}: PotPositionAdjustModalProps) => {
+  const handlePositionSelect = (position: { x: number; y: number }) => {
+    onApply(position);
+  };
+
+  const positionOptions = [
+    { label: "왼쪽 가운데", x: 25, y: 50 },
+    { label: "정중앙", x: 50, y: 50 },
+    { label: "오른쪽 가운데", x: 75, y: 50 },
+    { label: "왼쪽 아래", x: 25, y: 80 },
+    { label: "가운데 아래", x: 50, y: 80 },
+    { label: "오른쪽 아래", x: 75, y: 80 }
+  ];
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <div className="flex flex-col gap-4">
+        {selectedPot ? (
+          <div className="flex flex-col">
+            <div className="flex flex-col gap-4">
+              <div className="text-center font-pretendard text-subtitle font-bold text-text-03">위치 선택</div>
+              <div className="mx-auto grid grid-cols-3 gap-2">
+                {positionOptions.map((pos) => (
+                  <button
+                    key={`${pos.x}-${pos.y}`}
+                    onClick={() => handlePositionSelect({ x: pos.x, y: pos.y })}
+                    className={`whitespace-nowrap rounded px-3 py-2 text-center font-pretendard transition-colors ${
+                      currentPotPosition.x === pos.x && currentPotPosition.y === pos.y
+                        ? "bg-primary-default text-white"
+                        : "border border-gray-200 text-gray-600 hover:bg-gray-300"
+                    }`}
+                    title={pos.label}
+                  >
+                    {pos.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="text-body3 text-center text-text-04">화분을 먼저 선택해주세요.</div>
+        )}
+      </div>
+    </Modal>
+  );
+};
+
+export default PotPositionAdjustModal;

--- a/src/lib/types/api/profile.ts
+++ b/src/lib/types/api/profile.ts
@@ -1,3 +1,5 @@
+import type { MonthlyPlant } from "./public";
+
 export type Badge = {
   id: string;
   awardedAt: string;
@@ -24,11 +26,16 @@ export type Item = {
 
 export type Plant = {
   id: string;
-  name: string;
+  userId: string;
+  monthlyPlantId: number;
   stage: "SEED" | "SPROUT" | "GROWING" | "MATURE" | "HARVEST";
-  currentContributions: number;
-  createdAt: string;
+  harvestCount: number;
+  harvestedAt: string;
   updatedAt: string;
+  monthlyPlant: MonthlyPlant;
+  currentContributions: number;
+  totalContributions: number;
+  currentImageUrl: string;
 };
 
 export interface ProfileState {

--- a/src/lib/types/api/public.ts
+++ b/src/lib/types/api/public.ts
@@ -7,6 +7,9 @@ export type MonthlyPlant = {
   iconUrl: string;
   month: number;
   year: number;
+  createdAt: string;
+  updatedAt: string;
+  updatedById: string;
 };
 
 export type UpdateNote = {


### PR DESCRIPTION
## Title
feat: render plant using updated profile response and enable pot position adjustment

## Purpose
The backend now returns plant data based on GitHub contributions via the `/profile` API.  
This PR updates response types and renders the plant above the pot based on GitHub contributions.
Users can also **adjust the plant’s position**, allowing for more personalized and flexible customization.

## Changes
### API Types
- Updated `Plant` type in `src/lib/types/api/profile.ts` to match new backend response
- Updated `MonthlyPlant` type in `src/lib/types/api/public.ts` for consistency
- Ensured full type alignment between frontend and backend

### PotPositionAdjustModal.tsx
- Added a modal for adjusting the plant’s position above the pot
- Supports real-time preview and position selection synced with state

### StyleSection.tsx
- Integrated the modal into the customization interface
- Fetched plant data from `/profile` response and rendered it dynamically
- Applied store-based state management for position and preview
- Improved logic for displaying plant, background, and pot layers