### PR TITLE
feat: display UpdateSection on ShopPage using API response & Figma design

### DIFF
--- a/src/api/public.ts
+++ b/src/api/public.ts
@@ -12,7 +12,7 @@ export const getMonthlyPlant = async (): Promise<ApiResponse<MonthlyPlant>> => {
   }
 };
 
-export const getCurrentUpdate = async (): Promise<ApiResponse<CurrentUpdate>> => {
+export const getCurrentUpdate = async (): Promise<CurrentUpdate> => {
   try {
     const response = await API.get("/api/public/current-update");
     return response.data;

--- a/src/app/shop/_components/ShopPageClient.tsx
+++ b/src/app/shop/_components/ShopPageClient.tsx
@@ -3,6 +3,7 @@
 import ScrollTopButton from "@/components/shared/ScrollTopButton";
 import ShopHero from "./section/hero/ShopHero";
 import SellCropsSection from "./section/sell-crops/SellCropsSection";
+import UpdateSection from "./section/update/UpdateSection";
 
 const ShopPageClient = () => {
   return (
@@ -11,6 +12,7 @@ const ShopPageClient = () => {
         <div className="mx-auto flex min-h-screen w-full max-w-[1200px] flex-col items-center gap-16 px-8 pb-48 pt-12">
           <ShopHero />
           <SellCropsSection />
+          <UpdateSection />
         </div>
       </div>
       <ScrollTopButton />

--- a/src/app/shop/_components/section/update/BackgroundSectionCard.tsx
+++ b/src/app/shop/_components/section/update/BackgroundSectionCard.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import seed from "@/assets/images/seed.webp";
+import { Button } from "@/components/ui/Button";
+import { useCurrentUpdateStore } from "@/lib/store/currentUpdateStore";
+import Image from "next/image";
+import { useEffect } from "react";
+
+const BackgroundSectionCard = () => {
+  const { data: currentUpdate, isLoading, error, fetchCurrentUpdate } = useCurrentUpdateStore();
+  const backgroundItems = currentUpdate?.newItems.filter((item) => item.category === "background") || [];
+
+  useEffect(() => {
+    fetchCurrentUpdate();
+  }, [fetchCurrentUpdate]);
+
+  if (isLoading) {
+    return <div>{/* <LoadingSpinner /> */}</div>;
+  }
+
+  if (error) {
+    return <div>에러: {error}</div>;
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-[800px] flex-col items-center justify-center gap-10 rounded-2xl bg-secondary-light py-[3.75rem]">
+      <div className="w-full text-center text-heading text-primary-default">따끈-한 신상 업데이트</div>
+
+      <div className="flex w-full flex-col gap-10">
+        {backgroundItems.length > 0 ? (
+          <div className="flex w-full flex-row items-center justify-center gap-10">
+            {backgroundItems.map((item) => (
+              <div key={item.id} className="flex flex-col items-center justify-center gap-6">
+                <picture className="flex w-full justify-center">
+                  <Image
+                    src={item.imageUrl}
+                    alt={item.name}
+                    width={200}
+                    height={300}
+                    className="object-cover"
+                    priority
+                  />
+                </picture>
+                <div className="flex flex-row items-center gap-4">
+                  <Image src={seed} alt="seed" width={24} height={33} />
+                  <span className="text-title1 text-text-03">{item.price}</span>
+                </div>
+                <Button
+                  size="md"
+                  variant="secondaryLine"
+                  className="flex items-center justify-center px-8 text-body1 !font-medium"
+                >
+                  구매하기
+                </Button>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div>추후 업데이트 예정입니다.</div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default BackgroundSectionCard;

--- a/src/app/shop/_components/section/update/NewUpdatesCard.tsx
+++ b/src/app/shop/_components/section/update/NewUpdatesCard.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { Button } from "@/components/ui/Button";
+import { useCurrentUpdateStore } from "@/lib/store/currentUpdateStore";
+import Image from "next/image";
+import { useEffect } from "react";
+
+interface NewUpdatesCardProps {
+  isModalOpen: () => void;
+}
+
+const NewUpdatesCard = ({ isModalOpen }: NewUpdatesCardProps) => {
+  const { data: currentUpdate, isLoading, error, fetchCurrentUpdate } = useCurrentUpdateStore();
+
+  useEffect(() => {
+    fetchCurrentUpdate();
+  }, [fetchCurrentUpdate]);
+
+  if (isLoading) {
+    return <div>{/* <LoadingSpinner /> */}</div>;
+  }
+
+  if (error) {
+    return <div>에러: {error}</div>;
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-[800px] flex-col items-center justify-center gap-10 rounded-2xl bg-secondary-light py-[3.75rem]">
+      <div className="w-full text-center text-heading text-primary-default">따끈-한 신상 업데이트</div>
+
+      <div className="flex w-full flex-col gap-10">
+        {currentUpdate ? (
+          <div className="flex w-full flex-col gap-10">
+            <picture className="flex w-full justify-center">
+              <Image
+                src={currentUpdate.updateNote.imageUrl}
+                alt="update note"
+                width={700}
+                height={360}
+                className="object-cover"
+                priority
+              />
+            </picture>
+            <div className="flex w-full flex-row items-center justify-center gap-10">
+              <Button
+                size="lg"
+                variant="secondary"
+                className="flex items-center justify-center px-[60px] py-4 text-body1 !font-medium"
+                onClick={isModalOpen}
+              >
+                상세보기
+              </Button>
+              <Button
+                size="lg"
+                variant="secondaryLine"
+                className="flex items-center justify-center px-[60px] py-4 text-body1 !font-medium"
+              >
+                사러가기
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div>추후 업데이트 예정입니다.</div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default NewUpdatesCard;

--- a/src/app/shop/_components/section/update/PotSectionCard.tsx
+++ b/src/app/shop/_components/section/update/PotSectionCard.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import seed from "@/assets/images/seed.webp";
+import { Button } from "@/components/ui/Button";
+import { useCurrentUpdateStore } from "@/lib/store/currentUpdateStore";
+import Image from "next/image";
+import { useEffect } from "react";
+
+const PotSectionCard = () => {
+  const { data: currentUpdate, isLoading, error, fetchCurrentUpdate } = useCurrentUpdateStore();
+  const potItems = currentUpdate?.newItems.filter((item) => item.category === "pot") || [];
+
+  useEffect(() => {
+    fetchCurrentUpdate();
+  }, [fetchCurrentUpdate]);
+
+  if (isLoading) {
+    return <div>{/* <LoadingSpinner /> */}</div>;
+  }
+
+  if (error) {
+    return <div>에러: {error}</div>;
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-[800px] flex-col items-center justify-center gap-24 rounded-2xl bg-secondary-light py-[3.75rem]">
+      <div className="w-full text-center text-heading text-primary-default">따끈-한 신상 업데이트</div>
+
+      <div className="flex w-full flex-col gap-10">
+        {potItems.length > 0 ? (
+          <div className="flex w-full flex-row items-center justify-center gap-10">
+            {potItems.map((item) => (
+              <div key={item.id} className="flex flex-col items-center justify-center gap-6">
+                <picture className="flex w-full justify-center">
+                  <Image
+                    src={item.imageUrl}
+                    alt={item.name}
+                    width={150}
+                    height={150}
+                    className="object-cover"
+                    priority
+                  />
+                </picture>
+                <div className="flex flex-row items-center gap-4">
+                  <Image src={seed} alt="seed" width={24} height={33} />
+                  <span className="text-title1 text-text-03">{item.price}</span>
+                </div>
+                <Button
+                  size="md"
+                  variant="secondaryLine"
+                  className="flex items-center justify-center px-8 text-body1 !font-medium"
+                >
+                  구매하기
+                </Button>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div>추후 업데이트 예정입니다.</div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default PotSectionCard;

--- a/src/app/shop/_components/section/update/UpdateNoteModal.tsx
+++ b/src/app/shop/_components/section/update/UpdateNoteModal.tsx
@@ -1,0 +1,66 @@
+import { Button } from "@/components/ui/Button";
+import ModalItem from "@/components/ui/Modal";
+import type { UpdateNote } from "@/lib/types/api/public";
+import Image from "next/image";
+import { useEffect } from "react";
+
+interface UpdateNoteModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  updateNote: UpdateNote;
+}
+
+const UpdateNoteModal = ({ isOpen, onClose, updateNote }: UpdateNoteModalProps) => {
+  useEffect(() => {
+    const handleGlobalKeyDown = (e: globalThis.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener("keydown", handleGlobalKeyDown);
+      return () => {
+        document.removeEventListener("keydown", handleGlobalKeyDown);
+      };
+    }
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <ModalItem isOpen={isOpen} onClose={onClose} mode="default">
+      <div className="flex w-full flex-col gap-6">
+        <div className="flex w-full flex-col items-center gap-4">
+          <div className="font-pretendard text-subHeading font-bold text-text-04">업데이트 노트</div>
+          <div className="text-subtitle text-text-03">{updateNote.title}</div>
+        </div>
+
+        <picture className="flex w-full justify-center">
+          <Image
+            src={updateNote.imageUrl}
+            alt="update note"
+            width={400}
+            height={200}
+            className="object-cover"
+            priority
+          />
+        </picture>
+        <div className="whitespace-pre-wrap text-center text-caption text-text-03">{updateNote.description}</div>
+        <div className="flex gap-3">
+          <Button
+            type="submit"
+            variant="primary"
+            size="md"
+            className="w-full text-body1 text-text-01"
+            onClick={onClose}
+          >
+            닫기
+          </Button>
+        </div>
+      </div>
+    </ModalItem>
+  );
+};
+
+export default UpdateNoteModal;

--- a/src/app/shop/_components/section/update/UpdateSection.tsx
+++ b/src/app/shop/_components/section/update/UpdateSection.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { CaretCircleLeftIcon, CaretCircleRightIcon } from "@phosphor-icons/react";
+import { useState } from "react";
+import { Navigation } from "swiper/modules";
+import { Swiper, SwiperSlide } from "swiper/react";
+import NewUpdatesCard from "./NewUpdatesCard";
+
+// Import Swiper styles
+import { useCurrentUpdateStore } from "@/lib/store/currentUpdateStore";
+import "swiper/css";
+import "swiper/css/navigation";
+import "swiper/css/pagination";
+import BackgroundSectionCard from "./BackgroundSectionCard";
+import PotSectionCard from "./PotSectionCard";
+import UpdateNoteModal from "./UpdateNoteModal";
+
+const FeatureSection = () => {
+  const [isBeginning, setIsBeginning] = useState(true);
+  const [isEnd, setIsEnd] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const { data: currentUpdate } = useCurrentUpdateStore();
+
+  const handleModalOpen = () => {
+    setIsModalOpen(true);
+  };
+
+  const handleModalClose = () => {
+    setIsModalOpen(false);
+  };
+
+  return (
+    <>
+      <div className="relative mx-auto flex w-full items-center justify-center">
+        {/* Custom Navigation Buttons */}
+        <button
+          className={`feature-swiper-prev absolute left-0 z-10 text-text-03 ${
+            isBeginning ? "pointer-events-none opacity-0" : "opacity-100"
+          }`}
+          aria-label="이전 슬라이드"
+          disabled={isBeginning}
+        >
+          <CaretCircleLeftIcon size={48} />
+        </button>
+        <button
+          className={`feature-swiper-next absolute right-0 z-10 text-text-03 ${
+            isEnd ? "pointer-events-none opacity-0" : "opacity-100"
+          }`}
+          aria-label="다음 슬라이드"
+          disabled={isEnd}
+        >
+          <CaretCircleRightIcon size={48} />
+        </button>
+        <Swiper
+          modules={[Navigation]}
+          slidesPerView={1}
+          navigation={{
+            prevEl: ".feature-swiper-prev",
+            nextEl: ".feature-swiper-next"
+          }}
+          onReachBeginning={() => setIsBeginning(true)}
+          onReachEnd={() => setIsEnd(true)}
+          onFromEdge={() => {
+            setIsBeginning(false);
+            setIsEnd(false);
+          }}
+          className="feature-swiper w-full"
+        >
+          <SwiperSlide className="flex justify-center">
+            <NewUpdatesCard isModalOpen={handleModalOpen} />
+          </SwiperSlide>
+          <SwiperSlide className="flex justify-center">
+            <BackgroundSectionCard />
+          </SwiperSlide>
+          <SwiperSlide className="flex justify-center">
+            <PotSectionCard />
+          </SwiperSlide>
+        </Swiper>
+      </div>
+
+      {/* Modal rendered outside Swiper container */}
+      {currentUpdate?.updateNote && (
+        <UpdateNoteModal updateNote={currentUpdate.updateNote} isOpen={isModalOpen} onClose={handleModalClose} />
+      )}
+    </>
+  );
+};
+
+export default FeatureSection;

--- a/src/lib/store/currentUpdateStore.ts
+++ b/src/lib/store/currentUpdateStore.ts
@@ -1,0 +1,35 @@
+import { getCurrentUpdate } from "@/api/public";
+import { CurrentUpdate } from "@/lib/types/api/public";
+import { create } from "zustand";
+
+interface CurrentUpdateState {
+  data: CurrentUpdate | null;
+  isLoading: boolean;
+  error: string | null;
+  fetchCurrentUpdate: () => Promise<void>;
+}
+
+export const useCurrentUpdateStore = create<CurrentUpdateState>((set) => ({
+  data: null,
+  isLoading: false,
+  error: null,
+  fetchCurrentUpdate: async () => {
+    try {
+      set({ isLoading: true, error: null });
+      const response = await getCurrentUpdate();
+
+      if (response && typeof response === "object" && "month" in response && "year" in response) {
+        set({ data: response as CurrentUpdate, isLoading: false });
+      } else {
+        console.error("Invalid response format:", response);
+        set({ error: "잘못된 응답 형식입니다.", isLoading: false });
+      }
+    } catch (error) {
+      console.error("Current update API Exception:", error);
+      set({
+        error: error instanceof Error ? error.message : "업데이트 정보 조회에 실패했습니다.",
+        isLoading: false
+      });
+    }
+  }
+}));

--- a/src/lib/types/api/api.ts
+++ b/src/lib/types/api/api.ts
@@ -1,7 +1,7 @@
 export type ApiResponse<T> = {
   success: boolean;
   data: T;
-  error: {
+  error?: {
     message: string;
     code: string;
   };

--- a/src/lib/types/api/public.ts
+++ b/src/lib/types/api/public.ts
@@ -22,16 +22,19 @@ export type UpdateNote = {
 export type NewItem = {
   id: number;
   name: string;
-  description: string;
+  category: "background" | "pot" | "decoration";
+  mode: string | null;
   imageUrl: string;
-  type: "background" | "pot" | "decoration";
-  price?: number;
+  iconUrl: string;
+  price: number;
+  createdAt: string;
+  updatedAt: string;
+  updatedById: string;
 };
 
 export type CurrentUpdate = {
   month: number;
   year: number;
-  plant: MonthlyPlant;
   updateNote: UpdateNote;
   newItems: NewItem[];
 };


### PR DESCRIPTION
## Title  
feat: display UpdateSection on ShopPage using API response & Figma design

## Purpose  
- Use the newly added `getCurrentUpdate` public API to fetch update info and display the update note and new item list on the ShopPage (matching the Figma design).
- Improve modularity and state handling by introducing a Zustand store.

## Changes
### API Integration
- Updated types for `getCurrentUpdate` and `ApiResponse` to match backend response structure
- Added `currentUpdateStore` to fetch and manage update data with loading/error states

### UI Implementation
- Implemented `UpdateSection` to match the Figma layout and structure
- Created reusable subcomponents: `Card` (for new items), `Modal` (for full update notes)
- Rendered update note and item list from API response within `UpdateSection`