### PR TITLE
feat: implement shop system with seed-based purchasing (w/ pagination)

### DIFF
--- a/src/api/public.ts
+++ b/src/api/public.ts
@@ -1,5 +1,5 @@
 import { ApiResponse } from "@/lib/types/api/api";
-import { CurrentUpdate, MonthlyPlant } from "@/lib/types/api/public";
+import { CurrentUpdate, MonthlyPlant, ShopItem } from "@/lib/types/api/public";
 import API from "./api";
 
 export const getMonthlyPlant = async (): Promise<ApiResponse<MonthlyPlant>> => {
@@ -18,6 +18,16 @@ export const getCurrentUpdate = async (): Promise<CurrentUpdate> => {
     return response.data;
   } catch (error) {
     console.error("Failed to fetch current update:", error);
+    throw error;
+  }
+};
+
+export const getShopItems = async (): Promise<ShopItem[]> => {
+  try {
+    const response = await API.get("/api/public/items");
+    return response.data;
+  } catch (error) {
+    console.error("Failed to fetch shop items:", error);
     throw error;
   }
 };

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,8 +1,22 @@
 import { ApiResponse } from "@/lib/types/api/api";
+import { SeedResponse } from "@/lib/types/api/profile";
 import API from "./api";
 
 // Seed 관련 API
 export const seedApi = {
-  getSeeds: () => API.get<ApiResponse<{ userId: string; count: number }>>("/api/seeds"),
-  addSeeds: (count: number) => API.post<ApiResponse<{ message: string }>>("/api/seeds/add", { count })
+  getSeeds: () => API.get<ApiResponse<SeedResponse>>("/api/seeds"),
+
+  addSeeds: (count: number) => API.post<ApiResponse<SeedResponse>>("/api/seeds/add", { count }),
+
+  useSeeds: (count: number, itemId: number) => API.post<ApiResponse<SeedResponse>>("/api/seeds/use", { count, itemId })
+};
+
+export const shopApi = {
+  purchaseItem: async (itemId: number, price: number) => {
+    return seedApi.useSeeds(price, itemId);
+  },
+
+  sellCrops: async (cropIds: string[], totalPrice: number) => {
+    return seedApi.addSeeds(totalPrice);
+  }
 };

--- a/src/app/shop/_components/ShopPageClient.tsx
+++ b/src/app/shop/_components/ShopPageClient.tsx
@@ -1,11 +1,21 @@
 "use client";
 
 import ScrollTopButton from "@/components/shared/ScrollTopButton";
+import { useShopStore } from "@/lib/store/shopStore";
+import { useEffect } from "react";
 import ShopHero from "./section/hero/ShopHero";
+import BackgroundList from "./section/items/BackgroundList";
+import PotList from "./section/items/PotList";
 import SellCropsSection from "./section/sell-crops/SellCropsSection";
 import UpdateSection from "./section/update/UpdateSection";
 
 const ShopPageClient = () => {
+  const { backgroundItems, potItems, isLoading, fetchShopItems } = useShopStore();
+
+  useEffect(() => {
+    fetchShopItems();
+  }, [fetchShopItems]);
+
   return (
     <>
       <div className="relative w-full bg-sageGreen-100">
@@ -13,6 +23,8 @@ const ShopPageClient = () => {
           <ShopHero />
           <SellCropsSection />
           <UpdateSection />
+          <BackgroundList items={backgroundItems} loading={isLoading} />
+          <PotList items={potItems} loading={isLoading} />
         </div>
       </div>
       <ScrollTopButton />

--- a/src/app/shop/_components/section/items/BackgroundList.tsx
+++ b/src/app/shop/_components/section/items/BackgroundList.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import seed from "@/assets/images/seed.webp";
+import Pagination from "@/components/shared/Pagenation";
+import { Button } from "@/components/ui/Button";
+import { useShopStore } from "@/lib/store/shopStore";
+import { ShopItem } from "@/lib/types/api/public";
+import Image from "next/image";
+import { useState } from "react";
+
+interface BackgroundListProps {
+  items: ShopItem[];
+  loading: boolean;
+}
+
+const BackgroundList = ({ items, loading }: BackgroundListProps) => {
+  const [currentPage, setCurrentPage] = useState(1);
+  const limit = 6;
+
+  // shop store에서 구매 관련 기능 가져오기
+  const { purchaseItem, isLoading: purchasing } = useShopStore();
+
+  // 현재 페이지에 해당하는 아이템들
+  const startIndex = (currentPage - 1) * limit;
+  const endIndex = startIndex + limit;
+  const currentBackgroundItems = items.slice(startIndex, endIndex);
+
+  const handlePageChange = (newPage: number) => {
+    setCurrentPage(newPage);
+  };
+
+  // 구매 핸들러 추가
+  const handlePurchase = (item: ShopItem) => {
+    purchaseItem(item);
+  };
+
+  if (loading) {
+    return (
+      <div className="shadow-strong mx-auto flex w-full flex-col items-center justify-center gap-10 rounded-2xl bg-sageGreen-200 px-[60px] py-12 py-[3.75rem]">
+        <div className="text-center text-heading text-primary-default">배경화면</div>
+        <div>로딩 중...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="shadow-strong mx-auto flex w-full flex-col items-center justify-center gap-10 rounded-2xl bg-sageGreen-200 px-[60px] py-12 py-[3.75rem]">
+      <div className="text-center text-heading text-primary-default">배경화면</div>
+
+      <div className="flex w-full flex-col gap-10">
+        {currentBackgroundItems.length > 0 ? (
+          <div className="flex w-full flex-row items-end justify-center gap-10">
+            {currentBackgroundItems.map((item) => (
+              <div key={item.id} className="grid h-[400px] grid-rows-[1fr_auto] items-center gap-6">
+                <div className="flex items-center justify-center">
+                  <picture className="flex justify-center">
+                    <Image
+                      src={item.imageUrl}
+                      alt={item.name}
+                      width={200}
+                      height={300}
+                      className="object-cover"
+                      priority
+                    />
+                  </picture>
+                </div>
+
+                <div className="flex flex-col items-center gap-4">
+                  <div className="flex flex-row items-center gap-4">
+                    <Image src={seed} alt="seed" width={24} height={33} />
+                    <span className="text-title1 text-text-03">{item.price}</span>
+                  </div>
+                  <Button
+                    size="md"
+                    variant="secondaryLine"
+                    className="flex items-center justify-center px-8 text-body1 !font-medium"
+                    onClick={() => handlePurchase(item)}
+                    disabled={purchasing}
+                  >
+                    {purchasing ? "구매 중..." : "구매하기"}
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div>준비 중입니다.</div>
+        )}
+      </div>
+
+      {/* 페이지네이션 */}
+      {items.length > limit && (
+        <Pagination
+          Results={{ total: items.length }}
+          page={currentPage}
+          handlePageChange={handlePageChange}
+          limit={limit}
+        />
+      )}
+    </div>
+  );
+};
+
+export default BackgroundList;

--- a/src/app/shop/_components/section/items/PotList.tsx
+++ b/src/app/shop/_components/section/items/PotList.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import seed from "@/assets/images/seed.webp";
+import Pagination from "@/components/shared/Pagenation";
+import { Button } from "@/components/ui/Button";
+import { useShopStore } from "@/lib/store/shopStore";
+import { ShopItem } from "@/lib/types/api/public";
+import Image from "next/image";
+import { useState } from "react";
+
+interface PotListProps {
+  items: ShopItem[];
+  loading: boolean;
+}
+
+const PotList = ({ items, loading }: PotListProps) => {
+  const [currentPage, setCurrentPage] = useState(1);
+  const limit = 6;
+
+  // shop store에서 구매 관련 기능 가져오기
+  const { purchaseItem, isLoading: purchasing } = useShopStore();
+
+  // 현재 페이지에 해당하는 아이템들
+  const startIndex = (currentPage - 1) * limit;
+  const endIndex = startIndex + limit;
+  const currentPotItems = items.slice(startIndex, endIndex);
+
+  const handlePageChange = (newPage: number) => {
+    setCurrentPage(newPage);
+  };
+
+  // 구매 핸들러 추가
+  const handlePurchase = (item: ShopItem) => {
+    purchaseItem(item);
+  };
+
+  if (loading) {
+    return (
+      <div className="shadow-strong mx-auto flex w-full flex-col items-center justify-center gap-10 rounded-2xl bg-sageGreen-200 px-[60px] py-12 py-[3.75rem]">
+        <div className="text-center text-heading text-primary-default">화분</div>
+        <div>로딩 중...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="shadow-strong mx-auto flex w-full flex-col items-center justify-center gap-10 rounded-2xl bg-sageGreen-200 px-[60px] py-12 py-[3.75rem]">
+      <div className="text-center text-heading text-primary-default">화분</div>
+
+      <div className="flex w-full flex-col gap-10">
+        {currentPotItems.length > 0 ? (
+          <div className="flex w-full flex-row items-center justify-center gap-10">
+            {currentPotItems.map((item) => (
+              <div key={item.id} className="grid h-[220px] grid-rows-[1fr_auto] items-center justify-center gap-6">
+                <div className="flex flex-col items-center justify-center gap-6">
+                  <picture className="flex h-[100px] w-[100px] justify-center">
+                    <Image
+                      src={item.imageUrl}
+                      alt={item.name}
+                      width={100}
+                      height={100}
+                      className="object-cover"
+                      priority
+                    />
+                  </picture>
+                  <div className="flex flex-row items-center gap-4">
+                    <Image src={seed} alt="seed" width={24} height={33} />
+                    <span className="text-title1 text-text-03">{item.price}</span>
+                  </div>
+                </div>
+                <Button
+                  size="md"
+                  variant="secondaryLine"
+                  className="flex items-center justify-center px-8 text-body1 !font-medium"
+                  onClick={() => handlePurchase(item)}
+                  disabled={purchasing}
+                >
+                  {purchasing ? "구매 중..." : "구매하기"}
+                </Button>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div>준비 중입니다.</div>
+        )}
+      </div>
+
+      {/* 페이지네이션 */}
+      {items.length > limit && (
+        <Pagination
+          Results={{ total: items.length }}
+          page={currentPage}
+          handlePageChange={handlePageChange}
+          limit={limit}
+        />
+      )}
+    </div>
+  );
+};
+
+export default PotList;

--- a/src/app/shop/_components/section/update/BackgroundSectionCard.tsx
+++ b/src/app/shop/_components/section/update/BackgroundSectionCard.tsx
@@ -4,15 +4,10 @@ import seed from "@/assets/images/seed.webp";
 import { Button } from "@/components/ui/Button";
 import { useCurrentUpdateStore } from "@/lib/store/currentUpdateStore";
 import Image from "next/image";
-import { useEffect } from "react";
 
 const BackgroundSectionCard = () => {
-  const { data: currentUpdate, isLoading, error, fetchCurrentUpdate } = useCurrentUpdateStore();
+  const { data: currentUpdate, isLoading, error } = useCurrentUpdateStore();
   const backgroundItems = currentUpdate?.newItems.filter((item) => item.category === "background") || [];
-
-  useEffect(() => {
-    fetchCurrentUpdate();
-  }, [fetchCurrentUpdate]);
 
   if (isLoading) {
     return <div>{/* <LoadingSpinner /> */}</div>;

--- a/src/app/shop/_components/section/update/NewUpdatesCard.tsx
+++ b/src/app/shop/_components/section/update/NewUpdatesCard.tsx
@@ -3,18 +3,13 @@
 import { Button } from "@/components/ui/Button";
 import { useCurrentUpdateStore } from "@/lib/store/currentUpdateStore";
 import Image from "next/image";
-import { useEffect } from "react";
 
 interface NewUpdatesCardProps {
   isModalOpen: () => void;
 }
 
 const NewUpdatesCard = ({ isModalOpen }: NewUpdatesCardProps) => {
-  const { data: currentUpdate, isLoading, error, fetchCurrentUpdate } = useCurrentUpdateStore();
-
-  useEffect(() => {
-    fetchCurrentUpdate();
-  }, [fetchCurrentUpdate]);
+  const { data: currentUpdate, isLoading, error } = useCurrentUpdateStore();
 
   if (isLoading) {
     return <div>{/* <LoadingSpinner /> */}</div>;

--- a/src/app/shop/_components/section/update/PotSectionCard.tsx
+++ b/src/app/shop/_components/section/update/PotSectionCard.tsx
@@ -4,15 +4,10 @@ import seed from "@/assets/images/seed.webp";
 import { Button } from "@/components/ui/Button";
 import { useCurrentUpdateStore } from "@/lib/store/currentUpdateStore";
 import Image from "next/image";
-import { useEffect } from "react";
 
 const PotSectionCard = () => {
-  const { data: currentUpdate, isLoading, error, fetchCurrentUpdate } = useCurrentUpdateStore();
+  const { data: currentUpdate, isLoading, error } = useCurrentUpdateStore();
   const potItems = currentUpdate?.newItems.filter((item) => item.category === "pot") || [];
-
-  useEffect(() => {
-    fetchCurrentUpdate();
-  }, [fetchCurrentUpdate]);
 
   if (isLoading) {
     return <div>{/* <LoadingSpinner /> */}</div>;

--- a/src/app/shop/_components/section/update/UpdateSection.tsx
+++ b/src/app/shop/_components/section/update/UpdateSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { CaretCircleLeftIcon, CaretCircleRightIcon } from "@phosphor-icons/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Navigation } from "swiper/modules";
 import { Swiper, SwiperSlide } from "swiper/react";
 import NewUpdatesCard from "./NewUpdatesCard";
@@ -15,11 +15,16 @@ import BackgroundSectionCard from "./BackgroundSectionCard";
 import PotSectionCard from "./PotSectionCard";
 import UpdateNoteModal from "./UpdateNoteModal";
 
-const FeatureSection = () => {
+const UpdateSection = () => {
   const [isBeginning, setIsBeginning] = useState(true);
   const [isEnd, setIsEnd] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const { data: currentUpdate } = useCurrentUpdateStore();
+  const { data: currentUpdate, fetchCurrentUpdate } = useCurrentUpdateStore();
+
+  // UpdateSection에서 한 번만 API 호출
+  useEffect(() => {
+    fetchCurrentUpdate();
+  }, [fetchCurrentUpdate]);
 
   const handleModalOpen = () => {
     setIsModalOpen(true);
@@ -86,4 +91,4 @@ const FeatureSection = () => {
   );
 };
 
-export default FeatureSection;
+export default UpdateSection;

--- a/src/components/shared/Pagenation.tsx
+++ b/src/components/shared/Pagenation.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { CaretLeftIcon, CaretRightIcon } from "@phosphor-icons/react";
+import clsx from "clsx";
+
+type PaginationProps = {
+  Results?: { total: number };
+  page: number;
+  handlePageChange: (newPage: number) => void;
+  limit?: number;
+};
+
+const Pagination = ({ Results, page, handlePageChange, limit = 6 }: PaginationProps) => {
+  if (!Results || Results.total === 0) return null;
+
+  const totalPages = Math.ceil(Results.total / limit);
+
+  const maxPagesToShow = 5; // 보여줄 페이지 번호 개수
+  const startPage = Math.max(1, page - Math.floor(maxPagesToShow / 2));
+  const endPage = Math.min(totalPages, startPage + maxPagesToShow - 1);
+
+  return (
+    <div className="mt-16 flex items-center justify-center gap-3 tb:mt-6">
+      {/* <button
+        disabled={page === 1}
+        onClick={() => handlePageChange(1)}
+        className="flex h-7 w-7 items-center justify-center disabled:text-text-02"
+      >
+        <CaretDoubleLeft size={16} weight="bold" className="tb:w-[13px]" />
+      </button> */}
+
+      <button
+        disabled={page === 1}
+        onClick={() => handlePageChange(page - 1)}
+        className="flex h-7 w-7 items-center justify-center disabled:text-text-02"
+      >
+        <CaretLeftIcon size={16} weight="bold" className="tb:w-[13px]" />
+      </button>
+
+      {Array.from({ length: endPage - startPage + 1 }, (_, idx) => startPage + idx).map((pageNumber) => (
+        <button
+          key={pageNumber}
+          onClick={() => handlePageChange(pageNumber)}
+          className={clsx(
+            "text-body flex h-8 w-8 items-center justify-center rounded-full font-pretendard font-medium",
+            {
+              "bg-secondary-default text-text-01": page === pageNumber,
+              "bg-bg-01 text-text-04": page !== pageNumber
+            }
+          )}
+        >
+          {pageNumber}
+        </button>
+      ))}
+
+      <button
+        disabled={page === totalPages}
+        onClick={() => handlePageChange(page + 1)}
+        className="flex h-7 w-7 items-center justify-center disabled:text-text-02"
+      >
+        <CaretRightIcon size={16} weight="bold" className="tb:w-[13px]" />
+      </button>
+
+      {/* <button
+        disabled={page === totalPages}
+        onClick={() => handlePageChange(totalPages)}
+        className="flex h-7 w-7 items-center justify-center disabled:text-text-02"
+      >
+        <CaretDoubleRight size={16} weight="bold" className="tb:w-[13px]" />
+      </button> */}
+    </div>
+  );
+};
+
+export default Pagination;

--- a/src/lib/store/shopStore.ts
+++ b/src/lib/store/shopStore.ts
@@ -1,0 +1,162 @@
+import { getShopItems } from "@/api/public";
+import { shopApi } from "@/api/user";
+import { Plant } from "@/lib/types/api/profile";
+import { ShopItem } from "@/lib/types/api/public";
+import { create } from "zustand";
+import { useAuthStore } from "./authStore";
+import { useProfileStore } from "./profileStore";
+import { useToastStore } from "./useToaststore";
+
+interface ShopState {
+  // 아이템 상태
+  backgroundItems: ShopItem[];
+  potItems: ShopItem[];
+
+  // 판매용 작물 선택 상태
+  selectedCropsForSale: string[];
+
+  // 로딩 및 에러 상태
+  isLoading: boolean;
+  error: string | null;
+
+  // 아이템 관리 액션
+  fetchShopItems: () => Promise<void>;
+
+  // 구매 액션
+  purchaseItem: (item: ShopItem) => Promise<void>;
+
+  // 판매 액션
+  toggleCropSelection: (cropId: string) => void;
+  selectAllCrops: (crops: Plant[]) => void;
+  clearSelection: () => void;
+  sellSelectedCrops: (crops: Plant[]) => Promise<void>;
+}
+
+export const useShopStore = create<ShopState>((set, get) => ({
+  backgroundItems: [],
+  potItems: [],
+  selectedCropsForSale: [],
+  isLoading: false,
+  error: null,
+
+  fetchShopItems: async () => {
+    try {
+      set({ isLoading: true, error: null });
+      const response = await getShopItems();
+
+      const backgroundItems = response.filter((item) => item?.category === "background") || [];
+      const potItems = response.filter((item) => item?.category === "pot") || [];
+
+      set({
+        backgroundItems,
+        potItems,
+        isLoading: false
+      });
+    } catch (error) {
+      console.error("Failed to fetch shop items:", error);
+      set({
+        error: "상점 아이템을 불러오는데 실패했습니다.",
+        isLoading: false
+      });
+    }
+  },
+
+  purchaseItem: async (item: ShopItem) => {
+    const { addToast } = useToastStore.getState();
+    const { user } = useAuthStore.getState();
+    const { fetchProfile } = useProfileStore.getState();
+
+    // 로그인 상태 체크
+    if (!user) {
+      addToast("로그인이 필요합니다.", "warning");
+      return;
+    }
+
+    try {
+      set({ isLoading: true, error: null });
+
+      // seed 사용하여 아이템 구매
+      await shopApi.purchaseItem(item.id, item.price);
+
+      // 프로필 정보 새로고침 (seed 개수 업데이트)
+      await fetchProfile();
+
+      addToast(`${item.name}을(를) 구매했습니다!`, "success");
+      set({ isLoading: false });
+    } catch (error) {
+      console.error("Purchase failed:", error);
+      const errorMessage = error instanceof Error ? error.message : "구매에 실패했습니다.";
+
+      set({
+        error: errorMessage,
+        isLoading: false
+      });
+      addToast(errorMessage, "warning");
+    }
+  },
+
+  toggleCropSelection: (cropId: string) => {
+    set((state) => ({
+      selectedCropsForSale: state.selectedCropsForSale.includes(cropId)
+        ? state.selectedCropsForSale.filter((id) => id !== cropId)
+        : [...state.selectedCropsForSale, cropId]
+    }));
+  },
+
+  selectAllCrops: (crops: Plant[]) => {
+    // 수확 가능한 작물들만 선택
+    const harvestableIds = crops.filter((crop) => crop.stage === "HARVEST").map((crop) => crop.id);
+
+    set({ selectedCropsForSale: harvestableIds });
+  },
+
+  clearSelection: () => {
+    set({ selectedCropsForSale: [] });
+  },
+
+  sellSelectedCrops: async (crops: Plant[]) => {
+    const { selectedCropsForSale } = get();
+    const { addToast } = useToastStore.getState();
+    const { user } = useAuthStore.getState();
+    const { fetchProfile } = useProfileStore.getState();
+
+    // 로그인 상태 체크
+    if (!user) {
+      addToast("로그인이 필요합니다.", "warning");
+      return;
+    }
+
+    if (selectedCropsForSale.length === 0) {
+      addToast("판매할 작물을 선택해주세요.", "warning");
+      return;
+    }
+
+    try {
+      set({ isLoading: true, error: null });
+
+      // 선택된 작물들의 가격 계산 (임시로 개당 10 seed)
+      const totalPrice = selectedCropsForSale.length * 10;
+
+      // seed 적립
+      await shopApi.sellCrops(selectedCropsForSale, totalPrice);
+
+      // 프로필 정보 새로고침 (seed 개수 업데이트)
+      await fetchProfile();
+
+      // 선택 초기화
+      set({ selectedCropsForSale: [] });
+
+      addToast(`${selectedCropsForSale.length}개 작물을 판매했습니다! (+${totalPrice} seeds)`, "success");
+      set({ isLoading: false });
+    } catch (error) {
+      console.error("Sell failed:", error);
+      const errorMessage = error instanceof Error ? error.message : "판매에 실패했습니다.";
+
+      set({
+        error: errorMessage,
+        isLoading: false
+      });
+      addToast(errorMessage, "warning");
+    }
+  }
+}));

--- a/src/lib/types/api/profile.ts
+++ b/src/lib/types/api/profile.ts
@@ -24,6 +24,11 @@ export type Item = {
   updatedById: string;
 };
 
+export type SeedResponse = {
+  userId: string;
+  count: number;
+};
+
 export type Plant = {
   id: string;
   userId: string;

--- a/src/lib/types/api/public.ts
+++ b/src/lib/types/api/public.ts
@@ -22,7 +22,7 @@ export type UpdateNote = {
 export type NewItem = {
   id: number;
   name: string;
-  category: "background" | "pot" | "decoration";
+  category: "background" | "pot";
   mode: string | null;
   imageUrl: string;
   iconUrl: string;
@@ -30,6 +30,18 @@ export type NewItem = {
   createdAt: string;
   updatedAt: string;
   updatedById: string;
+};
+
+export type ShopItem = {
+  id: number;
+  name: string;
+  category: "background" | "pot";
+  mode: string | null;
+  imageUrl: string;
+  iconUrl: string;
+  price: number;
+  createdAt: string;
+  updatedAt: string;
 };
 
 export type CurrentUpdate = {


### PR DESCRIPTION
## Title  
feat: implement shop system with seed-based purchasing (w/ pagination)

## Purpose
- This PR establishes a basic shop system where users can view available items, purchase them using seeds, and have their purchases reflected in MyPage.
- It also reduces unnecessary API calls by optimizing the update fetch flow and improves UI consistency using a reusable pagination component.

## Changes  
### Shop Features
- Added `ShopItem` type and `getShopItems` public API
- Implemented `shopStore` for item purchasing and state management
- Added background/pot list components and integrated them into `ShopPageClient`
- Applied pagination to item lists for better navigation

### Seed API Enhancements
- Defined `SeedResponse` type for consistent seed state handling
- Updated `seedApi` with typed `getSeeds`, `addSeeds`, and `useSeeds` logic
- Applied seed deduction logic to `purchaseItem` flow

### Store & UI Logic
- Created reusable `Pagination` component for paginated list UIs
- Connected shop store logic with UI components to handle purchase flow
- Improved toast feedback and loading/error handling

### Optimize Update
- Removed redundant `fetchCurrentUpdate` calls from card components
- Centralized the fetch in `UpdateSection` to avoid multiple API requests

## Optional
- The crop selling feature (`sellSelectedCrops`) and its UI component `SellCropsSection` are prepared but not included in this commit due to pending field structure updates.
(These will be committed separately when the BE sys is ready.)