### PR TITLE
feat: finalize quantity-based crop selling system

### DIFF
--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -17,6 +17,6 @@ export const shopApi = {
   },
 
   sellCrops: async (cropIds: string[], totalPrice: number) => {
-    return seedApi.addSeeds(totalPrice);
+    return API.post("/api/garden/user-crops/sell", { cropIds, totalPrice });
   }
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import Footer from "@/components/layout/Footer";
 import Header from "@/components/layout/Header";
+import Toast from "@/components/shared/Toast";
 import TQProviders from "@/lib/providers/TQProvider";
 import "@/lib/styles/globals.css";
 import type { Metadata } from "next";
@@ -37,6 +38,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
             <Header />
             <main className="relative mx-auto w-full pt-20 tb:pt-0">{children}</main>
             <Footer />
+            <Toast />
           </NextIntlClientProvider>
         </body>
       </TQProviders>

--- a/src/app/shop/_components/ShopPageClient.tsx
+++ b/src/app/shop/_components/ShopPageClient.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import ScrollTopButton from "@/components/shared/ScrollTopButton";
+import { useAuthStore } from "@/lib/store/authStore";
+import { useProfileStore } from "@/lib/store/profileStore";
 import { useShopStore } from "@/lib/store/shopStore";
 import { useEffect } from "react";
 import ShopHero from "./section/hero/ShopHero";
@@ -10,18 +12,26 @@ import SellCropsSection from "./section/sell-crops/SellCropsSection";
 import UpdateSection from "./section/update/UpdateSection";
 
 const ShopPageClient = () => {
+  const { user } = useAuthStore();
+  const { fetchProfile } = useProfileStore();
   const { backgroundItems, potItems, isLoading, fetchShopItems } = useShopStore();
 
   useEffect(() => {
     fetchShopItems();
   }, [fetchShopItems]);
 
+  useEffect(() => {
+    if (user) {
+      fetchProfile();
+    }
+  }, [user, fetchProfile]);
+
   return (
     <>
       <div className="relative w-full bg-sageGreen-100">
         <div className="mx-auto flex min-h-screen w-full max-w-[1200px] flex-col items-center gap-16 px-8 pb-48 pt-12">
           <ShopHero />
-          <SellCropsSection />
+          {user && <SellCropsSection />}
           <UpdateSection />
           <BackgroundList items={backgroundItems} loading={isLoading} />
           <PotList items={potItems} loading={isLoading} />

--- a/src/app/shop/_components/section/sell-crops/SellCropsSection.tsx
+++ b/src/app/shop/_components/section/sell-crops/SellCropsSection.tsx
@@ -3,9 +3,43 @@
 import inventory from "@/assets/images/inventory.webp";
 import seed from "@/assets/images/seed.webp";
 import { Button } from "@/components/ui/Button";
+import { useProfileStore } from "@/lib/store/profileStore";
+import { useShopStore } from "@/lib/store/shopStore";
+import { useToastStore } from "@/lib/store/useToaststore";
 import Image from "next/image";
 
 const SellCropsSection = () => {
+  const { crops } = useProfileStore();
+  const { selectedCropsForSale, toggleCropSelection, selectAllCrops, clearSelection, sellSelectedCrops } =
+    useShopStore();
+  const { addToast } = useToastStore();
+
+  // 수확된 작물들 (crops 배열을 직접 사용)
+  const harvestableCrops = crops || [];
+
+  // quantity > 0인 작물들만 필터링
+  const availableCrops = harvestableCrops.filter((crop) => crop.quantity > 0);
+
+  // 선택된 작물 개수와 총 판매가 계산
+  const selectedCount = selectedCropsForSale.reduce((sum, item) => sum + item.count, 0);
+  const totalPrice = selectedCount * 100; // 임시로 개당 100 seed
+
+  const handleSelectAll = () => {
+    selectAllCrops(harvestableCrops);
+  };
+
+  const handleSell = () => {
+    if (selectedCount === 0) {
+      addToast("판매할 작물을 선택해주세요.", "warning");
+      return;
+    }
+    sellSelectedCrops(harvestableCrops);
+  };
+
+  const handleCancel = () => {
+    clearSelection();
+  };
+
   return (
     <div className="shadow-strong mx-auto flex w-full flex-col items-center justify-center gap-10 rounded-2xl bg-sageGreen-200 px-[60px] py-12 py-[3.75rem]">
       <div className="text-center text-heading text-primary-default">작물 판매하기</div>
@@ -13,28 +47,64 @@ const SellCropsSection = () => {
       <div className="flex w-full flex-col gap-10">
         <div className="flex w-full flex-row items-center justify-between px-[50px]">
           <div className="flex flex-row items-center gap-6">
-            <div className="text-center text-title1 text-text-03">선택된 작물 : n개</div>
-            <Button size="sm" variant="primary" className="text-body1 !font-medium">
+            <div className="text-center text-title1 text-text-03">선택된 작물 : {selectedCount}개</div>
+            <Button size="sm" variant="primary" className="text-body1 !font-medium" onClick={handleSelectAll}>
               전체 선택하기
             </Button>
           </div>
           <div className="flex flex-row items-center gap-4">
             <div className="text-center text-title1 text-text-03">총 판매가 :</div>
             <Image src={seed} alt="seed" width={24} height={33} />
-            {/* <small className="text-title1 text-text-03">{seedCount.toLocaleString()}</small> */}
+            <small className="text-title1 text-text-03">{totalPrice.toLocaleString()}</small>
           </div>
         </div>
+
         <div className="relative flex w-full flex-col">
           <Image src={inventory} alt="inventory" priority />
-          <div className="absolute inset-0 flex px-9 py-9">
-            <div className="flex flex-col gap-4">{/* TODO: 작물 업로드 후, 작동여부 확인필요*/}</div>
+          <div className="absolute inset-0 flex px-[45px] py-[40px]">
+            <div className="grid w-full grid-cols-8 gap-4">
+              {availableCrops.length > 0 ? (
+                availableCrops.map((crop) => (
+                  <div
+                    key={crop.id}
+                    className={`relative size-[74px] cursor-pointer ${
+                      selectedCropsForSale.find((item) => item.plantId === crop.id)
+                        ? ""
+                        : "hover:border-primary-200 border-gray-300"
+                    }`}
+                    onClick={() => toggleCropSelection(crop.id)}
+                  >
+                    <Image
+                      src={crop.monthlyPlant.cropImageUrl}
+                      alt={crop.monthlyPlant.name}
+                      className="object-cover"
+                      width={74}
+                      height={74}
+                      priority
+                    />
+                    {selectedCropsForSale.find((item) => item.plantId === crop.id) && (
+                      <div className="absolute inset-0 flex items-center justify-center rounded-md bg-primary-default bg-opacity-30" />
+                    )}
+                    <div className="text-border absolute -bottom-3 -right-1 flex items-center justify-center text-title1 text-white">
+                      {crop.quantity - (selectedCropsForSale.find((item) => item.plantId === crop.id)?.count || 0)}
+                    </div>
+                  </div>
+                ))
+              ) : (
+                <div className="col-span-8 flex items-center justify-center rounded-lg bg-black/50 text-center text-subtitle text-text-01">
+                  수확 가능한 작물이 없습니다.
+                </div>
+              )}
+            </div>
           </div>
         </div>
+
         <div className="flex w-full flex-row items-center justify-center gap-10">
           <Button
             size="lg"
             variant="primary"
             className="flex items-center justify-center px-[60px] py-4 text-body1 !font-medium"
+            onClick={handleSell}
           >
             판매하기
           </Button>
@@ -42,6 +112,7 @@ const SellCropsSection = () => {
             size="lg"
             variant="disabledLine"
             className="flex items-center justify-center px-[60px] py-4 text-body1 !font-medium"
+            onClick={handleCancel}
           >
             취소하기
           </Button>

--- a/src/lib/store/profileStore.ts
+++ b/src/lib/store/profileStore.ts
@@ -2,10 +2,12 @@ import { authApi } from "@/api/auth";
 import { ProfileState } from "@/lib/types/api/profile";
 import { create } from "zustand";
 
-export const useProfileStore = create<ProfileState>((set) => ({
+export const useProfileStore = create<ProfileState>((set, get) => ({
   user: null,
   seedCount: 0,
   badges: [],
+  items: [],
+  crops: [],
   equipped: {
     backgrounds: [],
     pots: []
@@ -14,25 +16,16 @@ export const useProfileStore = create<ProfileState>((set) => ({
   isLoading: false,
   error: null,
   fetchProfile: async () => {
+    set({ isLoading: true, error: null });
+
     try {
-      set({ isLoading: true, error: null });
       const response = await authApi.getProfile();
 
       if (response.success && response.data) {
-        const { user, seedCount, badges, equipped, plants } = response.data;
-        set({
-          user,
-          seedCount,
-          badges,
-          equipped,
-          plants,
-          isLoading: false
-        });
+        const { user, seedCount, badges, items, crops, equipped, plants } = response.data;
+        set({ user, seedCount, badges, items, crops, equipped, plants, isLoading: false });
       } else {
-        set({
-          error: "No profile data received",
-          isLoading: false
-        });
+        throw new Error("No profile data received");
       }
     } catch (error) {
       console.error("Profile API Exception:", error);
@@ -41,5 +34,49 @@ export const useProfileStore = create<ProfileState>((set) => ({
         isLoading: false
       });
     }
+  },
+
+  updateItemEquipStatus: (changes: Array<{ userItemId: string; equipped: boolean }>) => {
+    const currentState = get();
+    const updatedItems = currentState.items.map((item) => {
+      const change = changes.find((c) => c.userItemId === item.id);
+      if (change) {
+        return { ...item, equipped: change.equipped };
+      }
+      return item;
+    });
+
+    const equippedBackgrounds = updatedItems
+      .filter((item) => item.equipped && item.item.category === "background")
+      .map((item) => item.item);
+
+    const equippedPots = updatedItems
+      .filter((item) => item.equipped && item.item.category === "pot")
+      .map((item) => item.item);
+
+    set({
+      items: updatedItems,
+      equipped: {
+        backgrounds: equippedBackgrounds,
+        pots: equippedPots
+      }
+    });
+  },
+
+  decrementCropQuantity: (cropId: string) => {
+    set((state) => ({
+      crops: state.crops
+        .map((crop) => (crop.id === cropId && crop.quantity > 0 ? { ...crop, quantity: crop.quantity - 1 } : crop))
+        .filter((crop) => crop.quantity > 0)
+    }));
+  },
+
+  restoreCropQuantity: (restorations: Array<{ cropId: string; count: number }>) => {
+    set((state) => ({
+      crops: state.crops.map((crop) => {
+        const restoration = restorations.find((r) => r.cropId === crop.id);
+        return restoration ? { ...crop, quantity: crop.quantity + restoration.count } : crop;
+      })
+    }));
   }
 }));

--- a/src/lib/styles/globals.css
+++ b/src/lib/styles/globals.css
@@ -6,6 +6,18 @@
   .click-box {
     @apply absolute left-0 top-0 block h-full w-full cursor-pointer;
   }
+
+  .text-border {
+    text-shadow:
+      2px 2px 0 #000,
+      -2px -2px 0 #000,
+      2px -2px 0 #000,
+      -2px 2px 0 #000,
+      0 2px 0 #000,
+      2px 0 0 #000,
+      0 -2px 0 #000,
+      -2px 0 0 #000;
+  }
 }
 
 @layer components {

--- a/src/lib/types/api/profile.ts
+++ b/src/lib/types/api/profile.ts
@@ -24,6 +24,13 @@ export type Item = {
   updatedById: string;
 };
 
+export type UserItem = {
+  id: string;
+  equipped: boolean;
+  acquiredAt: string;
+  item: Item;
+};
+
 export type SeedResponse = {
   userId: string;
   count: number;
@@ -43,13 +50,33 @@ export type Plant = {
   currentImageUrl: string;
 };
 
+export type EquipItemResponse = {
+  category: string;
+  changes: Array<{
+    userItemId: string;
+    equipped: boolean;
+  }>;
+};
+
+export type Crop = {
+  id: string;
+  quantity: number;
+  createdAt: string;
+  updatedAt: string;
+  monthlyPlant: MonthlyPlant & {
+    cropImageUrl: string;
+  };
+};
 export interface ProfileState {
   user: {
     username: string;
     image: string | null;
+    isAdmin?: boolean;
   } | null;
   seedCount: number;
   badges: Badge[];
+  items: UserItem[];
+  crops: Crop[];
   equipped: {
     backgrounds: Item[];
     pots: Item[];
@@ -58,4 +85,7 @@ export interface ProfileState {
   isLoading: boolean;
   error: string | null;
   fetchProfile: () => Promise<void>;
+  updateItemEquipStatus: (changes: Array<{ userItemId: string; equipped: boolean }>) => void;
+  decrementCropQuantity: (cropId: string) => void;
+  restoreCropQuantity: (restorations: Array<{ cropId: string; count: number }>) => void;
 }


### PR DESCRIPTION
## Title
feat: finalize quantity-based crop selling system

## Purpose
- This PR completes the initial implementation of the crop selling system, which was previously postponed due to backend-side field restructuring.
- Users can now select harvested crops, specify quantities, and sell them in exchange for seeds—all within the `SellCropsSection` UI.
- The selling flow is integrated with the store state, API, and UI, enabling a consistent crop-selling experience for logged-in users.

## Changes
### API Integration
- Added `sellCrops` API call to post selected crop IDs and quantities for sale
- Applied **temporary** seed price logic (100 seeds per crop unit) in the selling request

### UI in SellCropsSection
- Implemented crop selection/deselection with quantity tracking
- Added "select all" functionality for available crops
- Displayed selected crop count and calculated total price
- Connected sell/cancel button logic to UI and API
- Show fallback message when no harvestable crops are available

### State Management
- Added `UserItem`, `Crop`, and `EquipItemResponse` types
- Extended `profileStore` with `items`, `crops`, and admin state
- Added state methods for crop quantity update and item equipment handling
- Refactored `shopStore` to support quantity-based crop sales

### Styles
- Added `.text-border` utility for text outline effect in emphasized UI elements

### Layout & Feedback
- Integrated global `Toast` component in `RootLayout` to support cross-page notifications

## Optional
> Still needs refinement... Do it ASAP, J.