### PR TITLE
feat: implement CROP tab, mode selection logic, and guard fetchProfile for safer data handling

### DIFF
--- a/src/app/mypage/_components/MyPageClient.tsx
+++ b/src/app/mypage/_components/MyPageClient.tsx
@@ -5,7 +5,7 @@ import LoadingText from "@/components/shared/LoadingText";
 import ScrollTopButton from "@/components/shared/ScrollTopButton";
 import { useProfileStore } from "@/lib/store/profileStore";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import SelectTab from "./SelectTab";
 import UserInfo from "./UserInfo";
 
@@ -13,6 +13,10 @@ const MyPageClient = () => {
   const router = useRouter();
   const { isLoading, fetchProfile } = useProfileStore();
   const [isInitialLoad, setIsInitialLoad] = useState(true);
+
+  const stableFetchProfile = useCallback(async () => {
+    await fetchProfile();
+  }, [fetchProfile]);
 
   useEffect(() => {
     const checkLoginStatus = async () => {
@@ -22,7 +26,10 @@ const MyPageClient = () => {
           alert("로그인이 필요한 서비스입니다.");
           router.push("/");
         } else {
-          await fetchProfile();
+          const currentState = useProfileStore.getState();
+          if (!currentState.user && !currentState.isLoading) {
+            await stableFetchProfile();
+          }
           setIsInitialLoad(false);
         }
       } catch (error) {
@@ -32,7 +39,7 @@ const MyPageClient = () => {
     };
 
     checkLoginStatus();
-  }, [router, fetchProfile]);
+  }, [router, stableFetchProfile]);
 
   if (isLoading || isInitialLoad) {
     return (


### PR DESCRIPTION
## Title
feat: implement CROP tab, mode selection logic, and guard fetchProfile for safer data handling

## Purpose  
- The profile API needed a guard to prevent duplicate calls triggered by StrictMode mounts.
- To achieve this, `fetchProfile` is wrapped in a stable callback and its execution is conditioned on store state.  
- In `StyleSection`, the store structure update required replacing `equipped` with an `items`-based approach for rendering backgrounds and pots, along with adding logic to determine available modes and set a default mode.  
- In CollectionSection, the newly included crop data in the API response is reflected by implementing the CROP tab, updating background and pot field paths to align with the latest schema, and removing toast logic—now managed globally—to prevent duplicate alerts.  
- Together, these changes align the MyPage collection and style sections with the updated store schema and API specifications, while making data fetching and rendering more stable.

## Changes
### Profile Fetch Handling
- Wrapped `fetchProfile` in a stable `useCallback` (`stableFetchProfile`)
- Added guard to call only when `!user && !isLoading`
- Replaced `useEffect` dependency from `fetchProfile` to `stableFetchProfile`
- Prevented duplicate API calls, especially in StrictMode

### StyleSection Updates
- Removed `equipped` usage and used `items` from `useProfileStore` instead
- Calculated `availableModes` with `useMemo` and set `defaultMode` on mount
- Updated props to pass `selectedPot.item` instead of `selectedPot`

### CollectionSection Updates
- Removed `equipped` usage, and filtered backgrounds/pots from `items` by `item.category` and `mode`  
- Implemented CROP tab view using new API response (`crop.monthlyPlant.cropImageUrl`, name tooltip, quantity badge)  
- Updated field paths:
  - Background: `background.item.iconUrl`, `background.item.name`, `acquiredAt`
  - Pot: `pot.item.iconUrl`, `pot.item.name`, `acquiredAt`
- Improved toast handling: switched to `useToastStore` with `useRef(hasShownToast)` to show warning **only once**
- Added `crops` length to empty state check and effect dependencies
- Removed unused `Toast` import/JSX