### PR TITLE
refactor: remove month/year fields from CurrentUpdate after switching to scheduled publishing

### DIFF
--- a/src/lib/store/currentUpdateStore.ts
+++ b/src/lib/store/currentUpdateStore.ts
@@ -18,7 +18,7 @@ export const useCurrentUpdateStore = create<CurrentUpdateState>((set) => ({
       set({ isLoading: true, error: null });
       const response = await getCurrentUpdate();
 
-      if (response && typeof response === "object" && "month" in response && "year" in response) {
+      if (response && typeof response === "object") {
         set({ data: response as CurrentUpdate, isLoading: false });
       } else {
         console.error("Invalid response format:", response);

--- a/src/lib/types/api/public.ts
+++ b/src/lib/types/api/public.ts
@@ -45,8 +45,6 @@ export type ShopItem = {
 };
 
 export type CurrentUpdate = {
-  month: number;
-  year: number;
   updateNote: UpdateNote;
   newItems: NewItem[];
 };


### PR DESCRIPTION
## Title
refactor: remove month/year fields from CurrentUpdate after switching to scheduled publishing

## Purpose
- Previously, `CurrentUpdate` relied on `month` and `year` fields for validation and typing.
- After migrating server logic to scheduled publishing, these fields became redundant.
- To align with the new publishing flow, the related validation checks and type definitions were removed.

## Changes  
- Simplified validation logic by removing `month` and `year` field checks (`currentUpdateStore.ts`)
- Removed `month` and `year` fields from `CurrentUpdate` type(`public.ts`)