### PR TITLE
feat: add dynamic CTA and hero section behavior based on login state

### DIFF
--- a/src/app/home/_components/section/cta/CtaSection.tsx
+++ b/src/app/home/_components/section/cta/CtaSection.tsx
@@ -1,10 +1,32 @@
+"use client";
+
 import farmer from "@/assets/images/farmer.webp";
 import { Button } from "@/components/ui/Button";
+import { useAuthStore } from "@/lib/store/authStore";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 
 const CtaSection = () => {
   const t = useTranslations("feature.cta");
+  const router = useRouter();
+  const { user, login } = useAuthStore();
+
+  // 로그인 상태 확인
+  const isLoggedIn = !!user;
+
+  const handleStartButtonClick = () => {
+    if (isLoggedIn) {
+      router.push("/shop");
+    } else {
+      login(); // GitHub OAuth 로그인 실행
+    }
+  };
+
+  const handleMoreInfo = () => {
+    window.open("https://github.com/reizvoll/git-plants-frontend", "_blank");
+  };
+
   return (
     <div className="mx-auto flex w-full max-w-[1000px] flex-col items-center justify-center py-[3.75rem]">
       <div className="flex w-full flex-row items-center justify-center gap-44">
@@ -16,10 +38,21 @@ const CtaSection = () => {
             </div>
           </div>
           <div className="flex flex-row items-start justify-center gap-4">
-            <Button variant="primary" size="md" className="flex items-center justify-center px-8 py-3">
-              {t("startButton")}
+            <Button
+              variant="primary"
+              size="md"
+              className="flex items-center justify-center px-8 py-3"
+              onClick={handleStartButtonClick}
+            >
+              {/* TODO: 텍스트 추후 적용 */}
+              {isLoggedIn ? "상점 바로가기" : t("startButton")}
             </Button>
-            <Button variant="primaryLine" size="md" className="flex items-center justify-center px-8 py-3">
+            <Button
+              variant="primaryLine"
+              size="md"
+              className="flex items-center justify-center px-8 py-3"
+              onClick={handleMoreInfo}
+            >
               {t("moreInfoButton")}
             </Button>
           </div>

--- a/src/app/home/_components/section/hero/MainHero.tsx
+++ b/src/app/home/_components/section/hero/MainHero.tsx
@@ -1,23 +1,51 @@
+"use client";
+
 import plant from "@/assets/images/plants.png";
 import { Button } from "@/components/ui/Button";
+import { useAuthStore } from "@/lib/store/authStore";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 
 const MainHero = () => {
   const t = useTranslations("main-hero");
+  const router = useRouter();
+  const { user, login } = useAuthStore();
+
+  // 로그인 상태 확인
+  const isLoggedIn = !!user;
+
+  const handleFirstButtonClick = () => {
+    if (isLoggedIn) {
+      router.push("/shop");
+    } else {
+      login(); // GitHub OAuth 로그인 실행
+    }
+  };
 
   return (
     <div className="shadow-emphasize flex items-center justify-center gap-16 rounded-[1rem] bg-[#F4EBDC]/80 px-16 py-16">
       <div className="flex w-full flex-col items-start gap-20">
         <div className="flex w-full flex-col items-start gap-12">
           <div className="w-full whitespace-pre-line font-galmuri text-heading text-primary-default">{t("title")}</div>
-          <div className="text-subtitle2 whitespace-pre-line font-galmuri text-primary-default">{t("subtitle")}</div>
+          <div className="whitespace-pre-line font-galmuri text-subtitle2 text-primary-default">{t("subtitle")}</div>
         </div>
         <div className="flex w-full flex-row items-start gap-4">
-          <Button variant="primary" size="md" className="flex items-center justify-center px-8 py-3">
-            {t("startButton")}
+          <Button
+            variant="primary"
+            size="md"
+            className="flex items-center justify-center px-8 py-3"
+            onClick={handleFirstButtonClick}
+          >
+            {/* TODO: */}
+            {isLoggedIn ? "상점 바로가기" : t("startButton")}
           </Button>
-          <Button variant="primaryLine" size="md" className="flex items-center justify-center px-8 py-3">
+          <Button
+            variant="primaryLine"
+            size="md"
+            className="flex items-center justify-center px-8 py-3"
+            onClick={() => router.push("/mypage")}
+          >
             {t("myPageButton")}
           </Button>
         </div>


### PR DESCRIPTION
## Title
feat: add dynamic CTA and hero section behavior based on login state

## Purpose
- Until now, the buttons in the main page CTA and hero section had no `onClick` handlers connected.
- By wiring up the button actions and making them dynamic based on the user’s login state, the flow becomes clearer and the overall user experience more consistent.
- As a result, unauthenticated users are naturally guided into the GitHub OAuth login flow, while authenticated users can directly access the service’s core features.

## Changes
### CtaSection
- Updated start button behavior depending on login state
  - Not logged in: trigger GitHub OAuth login
  - Logged in: navigate to the shop page

### MainHero
- Changed button behavior and text based on login state
  - Start button: dynamic handling depending on authentication
  - MyPage button: navigate to MyPage when clicked

### Others
- Added `"use client"` directive to switch to a client component
- Used `useAuthStore` hook for managing user authentication state