### PR TITLE
feat: implement item equip system with equipped field and fix modal width issue

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -19,5 +19,6 @@ export const authApi = {
     API.get<ProfileState>("/api/users/profile").then((response) => ({
       success: true,
       data: response.data
-    }))
+    })),
+  equipItem: (userItemId: string, equipped: boolean) => API.put(`/api/garden/user-items/${userItemId}`, { equipped })
 };

--- a/src/app/mypage/_components/PotPositionAdjustModal.tsx
+++ b/src/app/mypage/_components/PotPositionAdjustModal.tsx
@@ -1,4 +1,5 @@
 import Modal from "@/components/ui/Modal";
+import { useEffect } from "react";
 
 interface PotPositionAdjustModalProps {
   isOpen: boolean;
@@ -32,19 +33,37 @@ const PotPositionAdjustModal = ({
     { label: "오른쪽 아래", x: 75, y: 80 }
   ];
 
+  useEffect(() => {
+    const handleGlobalKeyDown = (e: globalThis.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener("keydown", handleGlobalKeyDown);
+      return () => {
+        document.removeEventListener("keydown", handleGlobalKeyDown);
+      };
+    }
+  }, [isOpen, onClose]);
+
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       <div className="flex flex-col gap-4">
         {selectedPot ? (
           <div className="flex flex-col">
             <div className="flex flex-col gap-4">
-              <div className="text-center font-pretendard text-subtitle font-bold text-text-03">위치 선택</div>
+              <div className="flex flex-col gap-2">
+                <div className="text-center font-pretendard text-subtitle font-bold text-text-03">위치 선택</div>
+                <span className="text-center font-pretendard text-body1 text-text-03">화분 위치를 선택해주세요.</span>
+              </div>
               <div className="mx-auto grid grid-cols-3 gap-2">
                 {positionOptions.map((pos) => (
                   <button
                     key={`${pos.x}-${pos.y}`}
                     onClick={() => handlePositionSelect({ x: pos.x, y: pos.y })}
-                    className={`whitespace-nowrap rounded px-3 py-2 text-center font-pretendard transition-colors ${
+                    className={`min-w-[120px] whitespace-nowrap rounded px-3 py-2 text-center font-pretendard transition-colors ${
                       currentPotPosition.x === pos.x && currentPotPosition.y === pos.y
                         ? "bg-primary-default text-white"
                         : "border border-gray-200 text-gray-600 hover:bg-gray-300"

--- a/src/lib/hooks/mypage/useItemEquip.ts
+++ b/src/lib/hooks/mypage/useItemEquip.ts
@@ -1,0 +1,82 @@
+import { authApi } from "@/api/auth";
+import { useProfileStore } from "@/lib/store/profileStore";
+import { useToastStore } from "@/lib/store/useToaststore";
+import { useMutation } from "@tanstack/react-query";
+
+interface EquipItemParams {
+  userItemId: string;
+  equipped: boolean;
+  category: "background" | "pot";
+  currentMode?: string;
+}
+
+export const useItemEquip = () => {
+  const { updateItemEquipStatus, items } = useProfileStore();
+  const addToast = useToastStore((state) => state.addToast);
+
+  const mutation = useMutation({
+    mutationFn: async ({ userItemId, equipped }: { userItemId: string; equipped: boolean }) => {
+      return authApi.equipItem(userItemId, equipped);
+    },
+    onMutate: async ({ userItemId, equipped, category, currentMode }: EquipItemParams) => {
+      // 낙관적 업데이트를 위한 이전 상태 저장
+      const previousState = useProfileStore.getState();
+
+      // 같은 카테고리의 다른 아이템들을 먼저 해제해야 할 수도 있음
+      const changes: Array<{ userItemId: string; equipped: boolean }> = [];
+
+      if (equipped && category === "background") {
+        // 같은 모드의 배경화면이 이미 장착되어 있다면 해제
+        const currentEquippedBackground = items?.find(
+          (item) => item.equipped && item.item.category === "background" && item.item.mode === currentMode
+        );
+
+        if (currentEquippedBackground && currentEquippedBackground.id !== userItemId) {
+          changes.push({ userItemId: currentEquippedBackground.id, equipped: false });
+        }
+      } else if (equipped && category === "pot") {
+        // 현재 장착된 화분이 있다면 해제
+        const currentEquippedPot = items?.find((item) => item.equipped && item.item.category === "pot");
+
+        if (currentEquippedPot && currentEquippedPot.id !== userItemId) {
+          changes.push({ userItemId: currentEquippedPot.id, equipped: false });
+        }
+      }
+
+      // 새로운 아이템 장착/해제
+      changes.push({ userItemId, equipped });
+
+      // 낙관적 업데이트 적용
+      updateItemEquipStatus(changes);
+
+      return { previousState, changes };
+    },
+    onError: (error, variables, context) => {
+      // 에러 발생 시 이전 상태로 롤백
+      if (context?.previousState) {
+        useProfileStore.setState(context.previousState);
+      }
+
+      console.error("Failed to equip/unequip item:", error);
+      addToast("아이템 장착에 실패했습니다.", "warning");
+    },
+    onSuccess: () => {
+      addToast("아이템이 성공적으로 장착되었습니다.", "success");
+    }
+  });
+
+  const equipItem = (params: EquipItemParams) => {
+    mutation.mutate({
+      userItemId: params.userItemId,
+      equipped: params.equipped,
+      category: params.category,
+      currentMode: params.currentMode
+    });
+  };
+
+  return {
+    equipItem,
+    isLoading: mutation.isPending,
+    error: mutation.error
+  };
+};

--- a/src/lib/hooks/mypage/useItemSelection.ts
+++ b/src/lib/hooks/mypage/useItemSelection.ts
@@ -1,32 +1,63 @@
 import { useEffect, useState } from "react";
+import { useItemEquip } from "./useItemEquip";
 
-// 배경화면 선택 전용 훅
-export const useBackgroundSelection = (backgrounds: any[], currentMode: string) => {
+interface ItemSelectionParams {
+  items: any[];
+  currentMode: string;
+  category: "background" | "pot";
+  equipped: { backgrounds: any[]; pots: any[] };
+}
+
+export const useItemSelection = ({ items, currentMode, category, equipped }: ItemSelectionParams) => {
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const { equipItem, isLoading } = useItemEquip();
 
-  // 모드 변경 시 첫 번째 배경화면으로 리셋
+  // 현재 장착된 아이템 찾기
+  const equippedItem =
+    category === "background" ? equipped.backgrounds.find((bg) => bg.mode === currentMode) : equipped.pots[0];
+
+  // 선택된 아이템 계산
+  const selectedItem = equippedItem
+    ? items.find((item) => item.item.id === equippedItem.id) || items[selectedIndex] || items[0] || null
+    : items[selectedIndex] || items[0] || null;
+
+  // 모드 변경 시 인덱스 리셋 (배경화면용)
   useEffect(() => {
-    setSelectedIndex(0);
-  }, [currentMode]);
+    if (category === "background") {
+      setSelectedIndex(0);
+    }
+  }, [currentMode, category]);
 
-  const selectedBackground = backgrounds[selectedIndex] || backgrounds[0] || null;
-
-  const selectBackground = (index: number) => {
+  // 아이템 선택/장착 처리
+  const handleItemSelect = (index: number) => {
     setSelectedIndex(index);
+
+    const item = items[index];
+    if (item) {
+      const isCurrentlyEquipped = isItemEquipped(item);
+      equipItem({
+        userItemId: item.id,
+        equipped: !isCurrentlyEquipped,
+        category,
+        currentMode
+      });
+    }
   };
 
-  return { selectedBackground, selectBackground, selectedIndex };
-};
-
-// 화분 선택 전용 훅
-export const usePotSelection = (pots: any[]) => {
-  const [selectedIndex, setSelectedIndex] = useState(0);
-
-  const selectedPot = pots[selectedIndex] || pots[0] || null;
-
-  const selectPot = (index: number) => {
-    setSelectedIndex(index);
+  // 아이템 장착 상태 확인
+  const isItemEquipped = (userItem: any) => {
+    if (category === "background") {
+      return equipped.backgrounds.some((bg) => bg.id === userItem.item.id && bg.mode === currentMode);
+    } else {
+      return equipped.pots.some((pot) => pot.id === userItem.item.id);
+    }
   };
 
-  return { selectedPot, selectPot, selectedIndex };
+  return {
+    selectedItem,
+    selectedIndex,
+    handleItemSelect,
+    isItemEquipped,
+    isLoading
+  };
 };


### PR DESCRIPTION
## Title
feat: implement item equip system with equipped field and fix modal width issue

## Purpose
- A new equip/unequip flow was needed to fully utilize the `equipped` field for managing background and pot items in MyPage.
- To support this, an API endpoint and client-side hooks were introduced, with refactored selection logic to unify handling of different item categories.
- The logic was enhanced to automatically unequip conflicting items, update default modes, and handle errors gracefully with rollback and user feedback.
- Additionally, a UI bug caused the modal width to shift when navigating to MyPage or changing routes, which was fixed with consistent width styling and improved closing behavior.

## Changes
### Equip System
- **API**
  - Added `equipItem` endpoint to toggle item `equipped` status
  - Integrated with backend `equipped` field to persist equip/unequip state

- **Hooks**
  - Introduced `useItemEquip` hook for managing item equip/unequip actions in MyPage
  - Implemented optimistic updates for smoother UX with rollback on errors
  - Added toast notifications to provide real-time user feedback

- **Selection Logic**
  - Unified `useBackgroundSelection` and `usePotSelection` into a single `useItemSelection` hook
  - Improved category-based item selection and state management for equipped items
  - Enhanced mode calculation logic to derive the default mode from currently equipped background

- **Code Cleanup**
  - Removed redundant TODO comments and simplified related logic for readability

### Modal  
- Fixed width inconsistency issue by applying `min-w` styling  
- Enabled ESC key press for closing modal in addition to click actions  
- Updated modal text for clearer user communication