### PR TITLE
feat: implement collection sorting via URL parameter and enhance crop UI

### DIFF
--- a/src/app/mypage/_components/CollectionSection.tsx
+++ b/src/app/mypage/_components/CollectionSection.tsx
@@ -36,6 +36,13 @@ const CollectionSection = ({ initialMode = "CROP" }: CollectionSectionProps) => 
 
   const handleModeChange = (mode: CollectionMode) => {
     setCurrentMode(mode);
+
+    // 모드 변경 시 현재 정렬이 해당 모드에서 지원되지 않으면 기본값으로 초기화
+    if (mode !== "CROP" && currentSort === "most_grown") {
+      const params = new URLSearchParams(searchParams);
+      params.delete("sort"); // 기본값(latest)으로 초기화
+      router.push(`?${params.toString()}`);
+    }
   };
 
   // 정렬 상태 변경 시 URL 업데이트

--- a/src/app/mypage/_components/CollectionSection.tsx
+++ b/src/app/mypage/_components/CollectionSection.tsx
@@ -1,46 +1,32 @@
 "use client";
 
 import inventory from "@/assets/images/inventory.webp";
+import seed from "@/assets/images/seed.webp";
 import { Button } from "@/components/ui/Button";
 import Dropdown from "@/components/ui/Dropdown";
+import { useCollectionSort, type CollectionMode } from "@/lib/hooks/mypage/useCollectionSort";
 import { useProfileStore } from "@/lib/store/profileStore";
 import { useToastStore } from "@/lib/store/useToaststore";
 import { formatDate } from "@/lib/utils/formatDate";
 import { FunnelIcon } from "@phosphor-icons/react";
 import Image from "next/image";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 interface CollectionSectionProps {
-  initialMode?: "CROP" | "BACKGROUND" | "POT";
+  initialMode?: CollectionMode;
 }
 
 const CollectionSection = ({ initialMode = "CROP" }: CollectionSectionProps) => {
-  const [currentMode, setCurrentMode] = useState<"CROP" | "BACKGROUND" | "POT">(initialMode);
-  const [currentSort, setCurrentSort] = useState<"LATEST" | "MOST_GROWN" | "A_Z">("LATEST");
+  const [currentMode, setCurrentMode] = useState<CollectionMode>(initialMode);
   const { items, crops } = useProfileStore();
   const addToast = useToastStore((state) => state.addToast);
 
-  const handleModeChange = (mode: "CROP" | "BACKGROUND" | "POT") => {
+  const { sortedData, getSortOptions, resetToDefault } = useCollectionSort({ items, crops });
+  const { backgrounds, pots, crops: ownedCrops } = sortedData;
+
+  const handleModeChange = (mode: CollectionMode) => {
     setCurrentMode(mode);
   };
-
-  const handleSortChange = (sort: "LATEST" | "MOST_GROWN" | "A_Z") => {
-    setCurrentSort(sort);
-  };
-
-  const {
-    backgrounds,
-    pots,
-    crops: ownedCrops
-  } = useMemo(() => {
-    if (!items) return { backgrounds: [], pots: [], crops: [] };
-
-    return {
-      backgrounds: items.filter((item) => item.item.category === "background"),
-      pots: items.filter((item) => item.item.category === "pot"),
-      crops: crops || []
-    };
-  }, [items, crops]);
 
   // update currentMode when initialMode changes
   useEffect(() => {
@@ -51,7 +37,7 @@ const CollectionSection = ({ initialMode = "CROP" }: CollectionSectionProps) => 
 
   useEffect(() => {
     const hasNoItems =
-      (currentMode === "CROP" && crops.length === 0) ||
+      (currentMode === "CROP" && ownedCrops.length === 0) ||
       (currentMode === "BACKGROUND" && backgrounds.length === 0) ||
       (currentMode === "POT" && pots.length === 0);
 
@@ -59,7 +45,7 @@ const CollectionSection = ({ initialMode = "CROP" }: CollectionSectionProps) => 
       hasShownToast.current = true;
       addToast("아이템을 찾을 수 없어요.", "warning");
     }
-  }, [currentMode, backgrounds.length, pots.length, crops.length, addToast]);
+  }, [currentMode, backgrounds.length, pots.length, ownedCrops.length, addToast]);
 
   const renderContent = () => {
     switch (currentMode) {
@@ -68,20 +54,24 @@ const CollectionSection = ({ initialMode = "CROP" }: CollectionSectionProps) => 
           <div className="grid auto-rows-min grid-cols-10 items-start gap-[10px] leading-none">
             {ownedCrops.length > 0 &&
               ownedCrops.map((crop) => (
-                <picture key={crop.id} className="group relative size-[74px]">
+                <picture key={crop.id} className="group relative size-[76px]">
                   <Image
                     src={crop.monthlyPlant.cropImageUrl}
                     alt={crop.monthlyPlant.name}
-                    className="object-cover"
-                    width={74}
-                    height={74}
-                    priority
+                    className="object-contain"
+                    fill
                   />
                   <div className="text-border absolute -bottom-1 -right-1 flex items-center justify-center text-title1 text-white">
                     {crop.quantity}
                   </div>
-                  <span className="group-hover:shadow-emphasize absolute left-1/2 top-[-8px] -translate-x-1/2 -translate-y-full whitespace-nowrap rounded-2xl bg-bg-01 px-4 py-3 text-center opacity-0 transition-all duration-200 group-hover:opacity-100">
+                  <span className="group-hover:shadow-emphasize absolute left-1/2 top-[-8px] flex -translate-x-1/2 -translate-y-full flex-col items-center justify-center whitespace-nowrap rounded-2xl bg-bg-01 px-4 py-3 text-center opacity-0 transition-all duration-200 group-hover:opacity-100">
                     <span className="block text-body2 text-primary-default">{crop.monthlyPlant.name}</span>
+                    <span className="text-mini text-brown-500">획득 날짜 : {formatDate(crop.createdAt)}</span>
+                    <span className="text-mini text-brown-500">획득 개수 : {crop.quantity} 개</span>
+                    {/* TODO: 판매가격 필드 추가 필요 */}
+                    <span className="flex items-center gap-1 text-mini text-brown-500">
+                      개당 판매가 : <Image src={seed} alt="seed" width={9} height={9} /> 10
+                    </span>
                   </span>
                 </picture>
               ))}
@@ -156,23 +146,7 @@ const CollectionSection = ({ initialMode = "CROP" }: CollectionSectionProps) => 
           />
           <div className="flex flex-row gap-[10px]">
             <Dropdown
-              items={[
-                {
-                  label: "최신순",
-                  onClick: () => handleSortChange("LATEST"),
-                  active: currentSort === "LATEST"
-                },
-                {
-                  label: "보유순",
-                  onClick: () => handleSortChange("MOST_GROWN"),
-                  active: currentSort === "MOST_GROWN"
-                },
-                {
-                  label: "가나다순",
-                  onClick: () => handleSortChange("A_Z"),
-                  active: currentSort === "A_Z"
-                }
-              ]}
+              items={getSortOptions(currentMode)}
               className="font-pretendard text-body1 text-sageGreen-900"
               mode="click"
             />
@@ -180,9 +154,12 @@ const CollectionSection = ({ initialMode = "CROP" }: CollectionSectionProps) => 
               variant="primary"
               size="md"
               className="shadow-normal flex items-center gap-2 text-body1"
-              onClick={() => {}}
+              onClick={() => {
+                resetToDefault();
+                addToast("정렬을 초기화했습니다.", "success");
+              }}
             >
-              자동 정렬
+              기본 정렬
               <FunnelIcon width={20} height={20} />
             </Button>
           </div>

--- a/src/lib/hooks/mypage/useCollectionSort.ts
+++ b/src/lib/hooks/mypage/useCollectionSort.ts
@@ -1,0 +1,81 @@
+import type { Crop, UserItem } from "@/lib/types/api/profile";
+import { useMemo, useState } from "react";
+
+export type SortType = "LATEST" | "MOST_GROWN" | "A_Z";
+export type CollectionMode = "CROP" | "BACKGROUND" | "POT";
+
+interface UseCollectionSortParams {
+  items: UserItem[] | null;
+  crops: Crop[] | null;
+}
+
+const sortFunctions = {
+  crops: {
+    LATEST: (a: Crop, b: Crop) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+    MOST_GROWN: (a: Crop, b: Crop) => b.quantity - a.quantity,
+    A_Z: (a: Crop, b: Crop) => a.monthlyPlant.name.localeCompare(b.monthlyPlant.name, "ko")
+  },
+  items: {
+    LATEST: (a: UserItem, b: UserItem) => new Date(b.acquiredAt).getTime() - new Date(a.acquiredAt).getTime(),
+    A_Z: (a: UserItem, b: UserItem) => a.item.name.localeCompare(b.item.name, "ko")
+  }
+};
+
+const sortOptions = {
+  LATEST: { label: "최신순", value: "LATEST" as const },
+  MOST_GROWN: { label: "보유순", value: "MOST_GROWN" as const },
+  A_Z: { label: "가나다순", value: "A_Z" as const }
+};
+
+export const useCollectionSort = ({ items, crops }: UseCollectionSortParams) => {
+  const [currentSort, setCurrentSort] = useState<SortType>("LATEST");
+
+  const sortedData = useMemo(() => {
+    if (!items) return { backgrounds: [], pots: [], crops: [] };
+
+    const [backgroundItems, potItems] = [
+      items.filter((item) => item.item.category === "background"),
+      items.filter((item) => item.item.category === "pot")
+    ];
+
+    // 작물 정렬
+    const sortedCrops = crops ? [...crops].sort(sortFunctions.crops[currentSort]) : [];
+
+    // 아이템 정렬 (MOST_GROWN은 작물에만 적용)
+    const itemSortFn = sortFunctions.items[currentSort as keyof typeof sortFunctions.items];
+    const sortedBackgrounds = itemSortFn ? [...backgroundItems].sort(itemSortFn) : backgroundItems;
+    const sortedPots = itemSortFn ? [...potItems].sort(itemSortFn) : potItems;
+
+    return {
+      backgrounds: sortedBackgrounds,
+      pots: sortedPots,
+      crops: sortedCrops
+    };
+  }, [items, crops, currentSort]);
+
+  const resetToDefault = () => {
+    setCurrentSort("LATEST");
+  };
+
+  const getSortOptions = (mode: CollectionMode) => {
+    const options = [sortOptions.LATEST, sortOptions.A_Z] as Array<(typeof sortOptions)[keyof typeof sortOptions]>;
+
+    if (mode === "CROP") {
+      options.splice(1, 0, sortOptions.MOST_GROWN);
+    }
+
+    return options.map((option) => ({
+      label: option.label,
+      onClick: () => setCurrentSort(option.value),
+      active: currentSort === option.value
+    }));
+  };
+
+  return {
+    currentSort,
+    sortedData,
+    handleSortChange: setCurrentSort,
+    resetToDefault,
+    getSortOptions
+  };
+};

--- a/src/lib/hooks/mypage/useCollectionSort.ts
+++ b/src/lib/hooks/mypage/useCollectionSort.ts
@@ -1,35 +1,34 @@
 import type { Crop, UserItem } from "@/lib/types/api/profile";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 
-export type SortType = "LATEST" | "MOST_GROWN" | "A_Z";
+export type SortType = "latest" | "most_grown" | "a_z";
 export type CollectionMode = "CROP" | "BACKGROUND" | "POT";
 
 interface UseCollectionSortParams {
   items: UserItem[] | null;
   crops: Crop[] | null;
+  currentSort: SortType;
 }
 
 const sortFunctions = {
   crops: {
-    LATEST: (a: Crop, b: Crop) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
-    MOST_GROWN: (a: Crop, b: Crop) => b.quantity - a.quantity,
-    A_Z: (a: Crop, b: Crop) => a.monthlyPlant.name.localeCompare(b.monthlyPlant.name, "ko")
+    latest: (a: Crop, b: Crop) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+    most_grown: (a: Crop, b: Crop) => b.quantity - a.quantity,
+    a_z: (a: Crop, b: Crop) => a.monthlyPlant.name.localeCompare(b.monthlyPlant.name, "ko")
   },
   items: {
-    LATEST: (a: UserItem, b: UserItem) => new Date(b.acquiredAt).getTime() - new Date(a.acquiredAt).getTime(),
-    A_Z: (a: UserItem, b: UserItem) => a.item.name.localeCompare(b.item.name, "ko")
+    latest: (a: UserItem, b: UserItem) => new Date(b.acquiredAt).getTime() - new Date(a.acquiredAt).getTime(),
+    a_z: (a: UserItem, b: UserItem) => a.item.name.localeCompare(b.item.name, "ko")
   }
 };
 
 const sortOptions = {
-  LATEST: { label: "최신순", value: "LATEST" as const },
-  MOST_GROWN: { label: "보유순", value: "MOST_GROWN" as const },
-  A_Z: { label: "가나다순", value: "A_Z" as const }
+  latest: { label: "최신순", value: "latest" as const },
+  most_grown: { label: "보유순", value: "most_grown" as const },
+  a_z: { label: "가나다순", value: "a_z" as const }
 };
 
-export const useCollectionSort = ({ items, crops }: UseCollectionSortParams) => {
-  const [currentSort, setCurrentSort] = useState<SortType>("LATEST");
-
+export const useCollectionSort = ({ items, crops, currentSort }: UseCollectionSortParams) => {
   const sortedData = useMemo(() => {
     if (!items) return { backgrounds: [], pots: [], crops: [] };
 
@@ -53,20 +52,16 @@ export const useCollectionSort = ({ items, crops }: UseCollectionSortParams) => 
     };
   }, [items, crops, currentSort]);
 
-  const resetToDefault = () => {
-    setCurrentSort("LATEST");
-  };
-
   const getSortOptions = (mode: CollectionMode) => {
-    const options = [sortOptions.LATEST, sortOptions.A_Z] as Array<(typeof sortOptions)[keyof typeof sortOptions]>;
+    const options = [sortOptions.latest, sortOptions.a_z] as Array<(typeof sortOptions)[keyof typeof sortOptions]>;
 
     if (mode === "CROP") {
-      options.splice(1, 0, sortOptions.MOST_GROWN);
+      options.splice(1, 0, sortOptions.most_grown);
     }
 
     return options.map((option) => ({
       label: option.label,
-      onClick: () => setCurrentSort(option.value),
+      value: option.value,
       active: currentSort === option.value
     }));
   };
@@ -74,8 +69,6 @@ export const useCollectionSort = ({ items, crops }: UseCollectionSortParams) => 
   return {
     currentSort,
     sortedData,
-    handleSortChange: setCurrentSort,
-    resetToDefault,
     getSortOptions
   };
 };

--- a/src/lib/hooks/mypage/useItemSelection.ts
+++ b/src/lib/hooks/mypage/useItemSelection.ts
@@ -1,20 +1,26 @@
+import { Item, UserItem } from "@/lib/types/api/profile";
 import { useEffect, useState } from "react";
 import { useItemEquip } from "./useItemEquip";
 
 interface ItemSelectionParams {
-  items: any[];
+  items: UserItem[];
   currentMode: string;
   category: "background" | "pot";
-  equipped: { backgrounds: any[]; pots: any[] };
+  equipped: { backgrounds: Item[]; pots: Item[] };
 }
 
 export const useItemSelection = ({ items, currentMode, category, equipped }: ItemSelectionParams) => {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const { equipItem, isLoading } = useItemEquip();
 
+  // equipped 객체
+  const isEquipped = equipped || { backgrounds: [], pots: [] };
+
   // 현재 장착된 아이템 찾기
   const equippedItem =
-    category === "background" ? equipped.backgrounds.find((bg) => bg.mode === currentMode) : equipped.pots[0];
+    category === "background"
+      ? isEquipped.backgrounds?.find((bg: Item) => bg.mode === currentMode)
+      : isEquipped.pots?.[0];
 
   // 선택된 아이템 계산
   const selectedItem = equippedItem
@@ -45,11 +51,11 @@ export const useItemSelection = ({ items, currentMode, category, equipped }: Ite
   };
 
   // 아이템 장착 상태 확인
-  const isItemEquipped = (userItem: any) => {
+  const isItemEquipped = (userItem: UserItem) => {
     if (category === "background") {
-      return equipped.backgrounds.some((bg) => bg.id === userItem.item.id && bg.mode === currentMode);
+      return isEquipped.backgrounds?.some((bg: Item) => bg.id === userItem.item.id && bg.mode === currentMode) || false;
     } else {
-      return equipped.pots.some((pot) => pot.id === userItem.item.id);
+      return isEquipped.pots?.some((pot: Item) => pot.id === userItem.item.id) || false;
     }
   };
 


### PR DESCRIPTION
## Title
feat: implement collection sorting via URL parameter and enhance crop UI

## Purpose
- Collection sorting was previously implemented with component state, which caused sorting not to work consistently across navigation.
- To fix this, sorting logic was moved into a new `useCollectionSort` hook and connected to URL parameters for more stable behavior.
- Unsupported modes now reset to the default sort to prevent inconsistent UI states.
- Crop cards were also improved to show clearer information such as acquisition date, count, and selling price.

**Why not state-based sorting?**
- State-based sorting could not persist across page navigation or sharing links, making the feature less reliable.
- With URL parameters, sorting is synced with navigation, can be shared via links, and behaves more consistently across modes.

## Changes
### Type Safety & Null Handling
- Replaced `any[]` with `UserItem[]` and `Item[]` in `useItemSelection` hook
- Added default values to `equipped` object to avoid undefined errors
- Enhanced `isItemEquipped` with null checks and optional chaining

### Sorting Logic
- Added `useCollectionSort` hook to modularize collection sorting
- Refactored `CollectionSection` to delegate sorting logic to the hook
- Replaced state-based sorting with URL parameter–based sorting
- Applied default sort fallback for unsupported modes

### Crop UI
- Added acquisition date, count, and selling price to crop cards
- Enhanced collection UI with dynamic sorting options and reset-to-default button