### PR TITLE
fix: improve session validation by handling getSession errors and clearing localStorage

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -9,11 +9,24 @@ export const authApi = {
   },
   signOut: () => API.post("/api/auth/signout"),
   getSession: async () => {
-    const response = await API.get<SessionResponse>("/api/auth/session");
-    return {
-      success: true,
-      data: response.data
-    };
+    try {
+      const response = await API.get<SessionResponse>("/api/auth/session");
+      if (response.status === 401) {
+        return {
+          success: false,
+          data: null
+        };
+      }
+      return {
+        success: true,
+        data: response.data
+      };
+    } catch (error) {
+      return {
+        success: false,
+        data: null
+      };
+    }
   },
   getProfile: () =>
     API.get<ProfileState>("/api/users/profile").then((response) => ({

--- a/src/lib/store/authStore.ts
+++ b/src/lib/store/authStore.ts
@@ -32,11 +32,13 @@ export const useAuthStore = create<AuthState>()(
           if (response.success && response.data?.user) {
             set({ user: response.data.user, error: null });
           } else {
-            set({ user: null, error: "인증 정보가 없습니다." });
+            set({ user: null, error: null });
+            localStorage.removeItem("auth-storage");
           }
         } catch (error) {
           console.error("Auth check error:", error);
-          set({ error: "인증 확인에 실패했습니다.", user: null });
+          set({ error: null, user: null });
+          localStorage.removeItem("auth-storage");
         } finally {
           set({ isPending: false });
         }


### PR DESCRIPTION
## Title
fix: improve session validation by handling getSession errors and clearing localStorage

## Purpose
- After login, the session was not properly maintained, and localStorage remained in an invalid state `{state: {user: null}, version: 0}`.
- The root causes were:
  1. **LocalStorage state issue**: Zustand persist stored invalid session state.
  2. **getSession API error handling**: `authApi.getSession()` returned `success: true` even on 401 errors.
  3. **Session validation logic**: `checkAuth()` did not properly handle API errors.
- To fix this, API error handling and localStorage cleanup were improved, ensuring consistent session state after login.

## Changes
### auth
  - Updated `getSession` to return `success: false` on 401 responses or exceptions

### Session validation logic
  - Updated `checkAuth()` to remove the `auth-storage` key in localStorage when session validation fails
  - Prevented invalid persisted state `{state: {user: null}, version: 0}` from remaining after login