### PR TITLE
fix: resolve infinite fetch loops and 429 errors in profile and components

### DIFF
--- a/src/app/home/_components/section/note/NoteSection.tsx
+++ b/src/app/home/_components/section/note/NoteSection.tsx
@@ -19,6 +19,9 @@ const NoteSection = () => {
   const [error, setError] = useState(false);
 
   useEffect(() => {
+    setIsLoading(true);
+    setError(false);
+
     getMonthlyPlant(language)
       .then((data) => {
         // 데이터 유효성 검사 추가

--- a/src/app/mypage/_components/MyPageClient.tsx
+++ b/src/app/mypage/_components/MyPageClient.tsx
@@ -5,30 +5,26 @@ import ScrollTopButton from "@/components/shared/ScrollTopButton";
 import { useAuthGuard } from "@/lib/hooks/auth/useAuthGuard";
 import { useProfileStore } from "@/lib/store/profileStore";
 import { useTranslations } from "next-intl";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import BadgeNotificationModal from "./BadgeNotificationModal";
 import SelectTab from "./SelectTab";
 import UserInfo from "./UserInfo";
 
 const MyPageClient = () => {
   const { isLoading: authLoading, isAuthenticated } = useAuthGuard();
-  const { isLoading, fetchProfile, newBadges } = useProfileStore();
+  const { isLoading, newBadges } = useProfileStore();
   const [showBadgeNotification, setShowBadgeNotification] = useState(false);
   const [currentBadgeIndex, setCurrentBadgeIndex] = useState(0);
   const t = useTranslations("mypage");
-
-  const stableFetchProfile = useCallback(async () => {
-    await fetchProfile();
-  }, [fetchProfile]);
 
   useEffect(() => {
     if (isAuthenticated && !isLoading) {
       const currentState = useProfileStore.getState();
       if (!currentState.user) {
-        stableFetchProfile();
+        currentState.fetchProfile();
       }
     }
-  }, [isAuthenticated, isLoading, stableFetchProfile]);
+  }, [isAuthenticated, isLoading]);
 
   useEffect(() => {
     if (newBadges && newBadges.length > 0 && !isLoading) {
@@ -45,7 +41,8 @@ const MyPageClient = () => {
         setShowBadgeNotification(true);
       }, 100);
     } else {
-      fetchProfile();
+      const profileState = useProfileStore.getState();
+      profileState.clearNewBadges();
       setCurrentBadgeIndex(0);
     }
   };

--- a/src/app/shop/_components/ShopPageClient.tsx
+++ b/src/app/shop/_components/ShopPageClient.tsx
@@ -13,18 +13,19 @@ import UpdateSection from "./section/update/UpdateSection";
 
 const ShopPageClient = () => {
   const { user } = useAuthStore();
-  const { fetchProfile } = useProfileStore();
-  const { backgroundItems, potItems, isLoading, fetchShopItems } = useShopStore();
+  const { backgroundItems, potItems, isLoading } = useShopStore();
 
   useEffect(() => {
-    fetchShopItems();
-  }, [fetchShopItems]);
+    const shopState = useShopStore.getState();
+    shopState.fetchShopItems();
+  }, []);
 
   useEffect(() => {
     if (user) {
-      fetchProfile();
+      const profileState = useProfileStore.getState();
+      profileState.fetchProfile();
     }
-  }, [user, fetchProfile]);
+  }, [user]);
 
   return (
     <>

--- a/src/app/shop/_components/section/update/UpdateSection.tsx
+++ b/src/app/shop/_components/section/update/UpdateSection.tsx
@@ -19,12 +19,13 @@ const UpdateSection = () => {
   const [isBeginning, setIsBeginning] = useState(true);
   const [isEnd, setIsEnd] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const { data: currentUpdate, fetchCurrentUpdate, error, isLoading } = useCurrentUpdateStore();
+  const { data: currentUpdate, error, isLoading } = useCurrentUpdateStore();
 
   // UpdateSection에서 한 번만 API 호출
   useEffect(() => {
-    fetchCurrentUpdate();
-  }, [fetchCurrentUpdate]);
+    const updateState = useCurrentUpdateStore.getState();
+    updateState.fetchCurrentUpdate();
+  }, []);
 
   const handleModalOpen = () => {
     setIsModalOpen(true);

--- a/src/lib/store/profileStore.ts
+++ b/src/lib/store/profileStore.ts
@@ -79,5 +79,9 @@ export const useProfileStore = create<ProfileState>((set, get) => ({
         return restoration ? { ...crop, quantity: crop.quantity + restoration.count } : crop;
       })
     }));
+  },
+
+  clearNewBadges: () => {
+    set({ newBadges: [] });
   }
 }));

--- a/src/lib/types/api/profile.ts
+++ b/src/lib/types/api/profile.ts
@@ -101,4 +101,5 @@ export interface ProfileState {
   updateItemEquipStatus: (changes: Array<{ userItemId: string; equipped: boolean }>) => void;
   decrementCropQuantity: (cropId: string) => void;
   restoreCropQuantity: (restorations: Array<{ cropId: string; count: number }>) => void;
+  clearNewBadges: () => void;
 }


### PR DESCRIPTION
## Title
fix: resolve infinite fetch loops and 429 errors in profile and components

## Purpose
- Badge modal closing and unstable store references caused infinite fetch loops, which led to repeated API calls and 429 Too Many Requests errors.
- To solve this, a lightweight `clearNewBadges` function was added to the profile store and types, and component logic was updated to use stable `getState` calls.
- Additionally, language change flow now resets loading and error states for a cleaner UX without stale data or leftover errors.

## Changes
### Profile Store
- Added `clearNewBadges()` in `src/lib/store/profileStore.ts` to reset badge state without triggering `fetchProfile`
- Updated `ProfileState` in `src/lib/types/api/profile.ts` with `clearNewBadges` type definition

### Components (MyPage & Shop)
- Replaced unstable hook dependencies with direct `store.getState()` calls
- Applied `clearNewBadges()` to prevent unnecessary profile refetch on badge modal close
- Optimized API calls so each page fetches data exactly once

### Language Handling
- Updated `useEffect` on language change to set `isLoading(true)` and `error(false)` before fetching
- Prevented stale data and error states from persisting across language switches