### PR TITLE
fix: switch image fetching in GET route from sequential to parallel & add debug logging for image API

### DIFF
--- a/src/app/api/mypage/[userId]/route.tsx
+++ b/src/app/api/mypage/[userId]/route.tsx
@@ -127,15 +127,13 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     try {
       console.log("Starting Sharp image composition...");
 
-      // 1. download background image
-      const bgResponse = await fetch(backgroundUrl);
-      if (!bgResponse.ok) throw new Error(`Failed to fetch background: ${bgResponse.status}`);
-      const bgBuffer = await bgResponse.arrayBuffer();
+      // 1&2. download images in parallel
+      const [bgResponse, potResponse] = await Promise.all([fetch(backgroundUrl), fetch(potUrl)]);
 
-      // 2. download pot image
-      const potResponse = await fetch(potUrl);
+      if (!bgResponse.ok) throw new Error(`Failed to fetch background: ${bgResponse.status}`);
       if (!potResponse.ok) throw new Error(`Failed to fetch pot: ${potResponse.status}`);
-      const potBuffer = await potResponse.arrayBuffer();
+
+      const [bgBuffer, potBuffer] = await Promise.all([bgResponse.arrayBuffer(), potResponse.arrayBuffer()]);
 
       console.log("Downloaded images, starting composition...");
 


### PR DESCRIPTION
## Title  
fix: switch image fetching in GET route from sequential to parallel & add debug logging for image API

## Purpose  
- To find the root cause of the 500 errors occurring in the image API, the fetching strategy was first switched from sequential to parallel.  
- Additionally, debug logging was added to better trace and analyze errors.

## Changes  
- Updated GET route to fetch images in parallel instead of sequential order  
- Added debug logging in image API flow to trace failures and responses