### PR TITLE
feat: copy markdown image link in Copy Link button & remove console logs in profile/image flow

### DIFF
--- a/src/app/api/mypage/[userId]/route.tsx
+++ b/src/app/api/mypage/[userId]/route.tsx
@@ -29,16 +29,11 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     const apiUrl = process.env.NEXT_PUBLIC_API_URL;
     const fullUrl = `${apiUrl}/api/public/profile/${userId}`;
 
-    console.log("Trying to fetch from:", fullUrl);
-
     const profileResponse = await fetch(fullUrl, {
       headers: {
         Accept: "application/json"
       }
     });
-
-    console.log("Response status:", profileResponse.status);
-    console.log("Response ok:", profileResponse.ok);
 
     if (!profileResponse.ok) {
       throw new Error(`Failed to fetch profile: ${profileResponse.status} ${profileResponse.statusText}`);
@@ -47,9 +42,6 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     const result = await profileResponse.json();
     const profileData = result.data || result;
 
-    console.log("Profile data from backend:", profileData);
-    console.log("Settings from URL:", { potX, potY, width, height });
-
     // set size from URL parameters
     const customSize = { width, height };
 
@@ -57,8 +49,6 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     const backgroundUrl = profileData.equipped?.backgrounds[0]?.imageUrl;
     const potUrl = profileData.equipped?.pots[0]?.iconUrl;
     const plantUrl = profileData.plants[0]?.currentImageUrl;
-
-    console.log("URLs from backend:", { backgroundUrl, potUrl, plantUrl });
 
     // validate URLs
     if (!backgroundUrl) throw new Error("Background URL is missing");
@@ -104,21 +94,12 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 
     // compose image using Sharp
     try {
-      console.log("Starting Sharp image composition...");
-
       // 1&2&3. download images in parallel (including plant GIF)
-      console.log("Fetching images in parallel...");
       const [bgResponse, potResponse, plantResponse] = await Promise.all([
         fetch(backgroundUrl),
         fetch(potUrl),
         fetch(plantUrl)
       ]);
-
-      console.log("Fetch responses:", {
-        bgStatus: bgResponse.status,
-        potStatus: potResponse.status,
-        plantStatus: plantResponse.status
-      });
 
       if (!bgResponse.ok) throw new Error(`Failed to fetch background: ${bgResponse.status} from ${backgroundUrl}`);
       if (!potResponse.ok) throw new Error(`Failed to fetch pot: ${potResponse.status} from ${potUrl}`);
@@ -135,8 +116,6 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
         potSize: potBuffer.byteLength,
         plantSize: plantBuffer.byteLength
       });
-
-      console.log("Downloaded images, starting composition...");
 
       // 3. compose image using Sharp
       const compositeImage = await sharp(Buffer.from(bgBuffer))

--- a/src/app/mypage/_components/StyleSection.tsx
+++ b/src/app/mypage/_components/StyleSection.tsx
@@ -143,7 +143,8 @@ const StyleSection = ({ onNavigateToCollection }: StyleSectionProps) => {
                 if (user?.username) {
                   const baseUrl = window.location.origin;
                   const apiUrl = `${baseUrl}/api/mypage/${user.username}?mode=${currentMode}&width=${customSize.width}&height=${customSize.height}&potX=${potPosition.x}&potY=${potPosition.y}`;
-                  await navigator.clipboard.writeText(apiUrl);
+                  const mdx = `[![${user.username}'s Garden](${apiUrl})](${baseUrl})`;
+                  await navigator.clipboard.writeText(mdx);
                   addToast(t("copyLinkSuccess"), "success");
                 } else {
                   await navigator.clipboard.writeText(window.location.href);


### PR DESCRIPTION
## Title  
feat: copy markdown image link in Copy Link button & remove console logs in profile/image flow

## Purpose  
- The "Copy Link" button was enhanced to copy a markdown-formatted image link instead of a plain URL, making it immediately usable in GitHub READMEs and markdown documents.  
- Additionally, unnecessary `console.log` statements from the profile fetching and image composition process were removed to keep logs clean and focused on debugging.

## Changes  
- Updated clipboard logic in Copy Link button to generate markdown image link  
- Copy code Example: `[![username's Garden](api_url)](client_url)`
  - **api_url** → API endpoint that dynamically generates the user’s garden image  
    - This URL produces the garden image based on the user’s state.  
  - **client_url** → The base client page where the image should redirect when clicked  
    - When the image in the README is clicked, the user is taken to this main page.

- Removed redundant console logs in:  
  - Profile fetching flow  
  - Image composition process

## Optional
The image will be displayed as follows!

[![reizvoll's Garden](https://git-plants-frontend.vercel.app/api/mypage/reizvoll?mode=GARDEN&width=400&height=300&potX=50&potY=80)](https://git-plants-frontend.vercel.app)