### PR TITLE
fix: move hasRun check inside !isLoading block to ensure redirect executes

### DIFF
--- a/src/app/auth/callback/_components/CallbackClient.tsx
+++ b/src/app/auth/callback/_components/CallbackClient.tsx
@@ -14,9 +14,6 @@ export default function CallbackClient({ error }: { error?: string }) {
   const t = useTranslations("auth.callback");
 
   useEffect(() => {
-    if (hasRun.current) return;
-    hasRun.current = true;
-
     if (error) {
       router.push(`/error?message=${encodeURIComponent(error)}`);
       return;
@@ -24,6 +21,9 @@ export default function CallbackClient({ error }: { error?: string }) {
 
     // useAuth will handle authentication automatically
     if (!isLoading) {
+      if (hasRun.current) return;
+      hasRun.current = true;
+
       if (user) {
         router.push("/");
       } else {


### PR DESCRIPTION
## Title
fix: move hasRun check inside !isLoading block to ensure redirect executes

## Purpose
- Redirect was not triggered even when user data existed because `hasRun.current` was set to true before `!isLoading` condition.
- This caused the effect to return early, skipping the actual redirect logic.
- By moving the `hasRun` check inside the `!isLoading` block, the redirect now executes correctly once loading is complete.

## Changes
- Updated `CallbackClient.tsx` to place `hasRun` guard inside the `!isLoading` condition
- Ensured that redirect runs once user data is available and prevents duplicate executions