### PR TITLE
fix: add gif parameter to resolve GitHub camo proxy SVG conversion issue

### DIFF
--- a/src/app/api/mypage/[userId]/route.tsx
+++ b/src/app/api/mypage/[userId]/route.tsx
@@ -15,6 +15,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     const mode = searchParams.get("mode") || "GARDEN"; // default is garden
     const potX = parseFloat(searchParams.get("potX") || "50");
     const potY = parseFloat(searchParams.get("potY") || "80");
+    const format = searchParams.get("format") || "gif"; // default is gif
 
     // set default size based on mode
     const defaultWidth = mode === "MINI" ? 267 : 400; // 267px for mini, 400px for garden
@@ -23,8 +24,8 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     const width = parseInt(searchParams.get("width") || defaultWidth.toString());
     const height = parseInt(searchParams.get("height") || defaultHeight.toString());
 
-    // create cache key for GIF
-    const cacheKey = `${userId}-${potX}-${potY}-${width}-${height}-gif`;
+    // create cache key including format
+    const cacheKey = `${userId}-${potX}-${potY}-${width}-${height}-${format}`;
 
     // fetch profile data from backend
     const apiUrl = process.env.NEXT_PUBLIC_API_URL;


### PR DESCRIPTION
## Title  
fix: add gif parameter to resolve GitHub camo proxy SVG conversion issue

## Purpose  
### Issues  
- On GitHub README, when clicking an image proxied through `camo.github`, the request was sometimes converted into an SVG instead of a GIF.
- This caused the intended animated GIF to be lost, breaking the consistency of animation behavior.

### Solution (In Progress)  
- Added a `gif` parameter to explicitly request GIF format when proxied through `GitHub camo`.
- This is an attempt to make the image format more deterministic, but further verification is needed to ensure full resolution of the issue.

## Changes  
- Updated image response logic to append a `gif` parameter in proxied requests
- Adjusted handling of GitHub camo requests to reduce unintended SVG conversion