### PR TITLE
fix: align clipboard link with gif format parameter & add equipped item validation with localization

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -113,6 +113,7 @@
       "copyLink": "Copy Link",
       "copyLinkSuccess": "Link copied to clipboard!",
       "copyLinkError": "Failed to copy link.",
+      "haveEquipped": "Please equip both background and pot.",
       "background": "Background",
       "noBackground": "No background yet.",
       "pot": "Pot",

--- a/locale/ko.json
+++ b/locale/ko.json
@@ -113,6 +113,7 @@
       "copyLink": "링크 복사하기",
       "copyLinkSuccess": "링크가 복사되었습니다!",
       "copyLinkError": "링크 복사에 실패했습니다.",
+      "haveEquipped": "배경화면과 화분을 모두 장착해주세요.",
       "background": "배경화면",
       "noBackground": "배경화면이 존재하지 않습니다.",
       "pot": "화분",

--- a/src/app/mypage/_components/StyleSection.tsx
+++ b/src/app/mypage/_components/StyleSection.tsx
@@ -141,6 +141,15 @@ const StyleSection = ({ onNavigateToCollection }: StyleSectionProps) => {
             onClick={async () => {
               try {
                 if (user?.username) {
+                  // Check if background and pot are equipped
+                  const hasEquippedBackground = equipped?.backgrounds && equipped.backgrounds.length > 0;
+                  const hasEquippedPot = equipped?.pots && equipped.pots.length > 0;
+
+                  if (!hasEquippedBackground || !hasEquippedPot) {
+                    addToast(t("haveEquipped"), "warning");
+                    return;
+                  }
+
                   const baseUrl = window.location.origin;
                   const apiUrl = `${baseUrl}/api/mypage/${user.username}?format=gif&mode=${currentMode}&width=${customSize.width}&height=${customSize.height}&potX=${potPosition.x}&potY=${potPosition.y}`;
                   const mdx = `[![${user.username}'s Garden](${apiUrl})](${baseUrl})`;

--- a/src/app/mypage/_components/StyleSection.tsx
+++ b/src/app/mypage/_components/StyleSection.tsx
@@ -142,7 +142,7 @@ const StyleSection = ({ onNavigateToCollection }: StyleSectionProps) => {
               try {
                 if (user?.username) {
                   const baseUrl = window.location.origin;
-                  const apiUrl = `${baseUrl}/api/mypage/${user.username}?mode=${currentMode}&width=${customSize.width}&height=${customSize.height}&potX=${potPosition.x}&potY=${potPosition.y}`;
+                  const apiUrl = `${baseUrl}/api/mypage/${user.username}?format=gif&mode=${currentMode}&width=${customSize.width}&height=${customSize.height}&potX=${potPosition.x}&potY=${potPosition.y}`;
                   const mdx = `[![${user.username}'s Garden](${apiUrl})](${baseUrl})`;
                   await navigator.clipboard.writeText(mdx);
                   addToast(t("copyLinkSuccess"), "success");


### PR DESCRIPTION
## Title
fix: align clipboard link with gif format parameter & add equipped item validation with localization

## Purpose
- Previously, the SVG conversion issue from GitHub’s camo proxy was resolved by applying the format=gif parameter, but this change was not reflected in the clipboard link generation flow.
- This update ensures that copied links now follow the same format, providing consistent image rendering across environments including GitHub README files.
- Additionally, validation was added to prevent link generation when background and pot are not equipped, along with new localization strings to support the validation message.

## Changes
- Updated clipboard link URL to include the `format=gif` parameter
- Added validation to check for equipped background and pot before generating the link
- Introduced new localization string (`haveEquipped`) for the validation warning message