### PR TITLE
feat: enhance auth flow with sessionStorage redirect and smarter logout handling

### DIFF
--- a/src/app/auth/callback/_components/CallbackClient.tsx
+++ b/src/app/auth/callback/_components/CallbackClient.tsx
@@ -32,7 +32,14 @@ export default function CallbackClient(props: CallbackClientProps) {
       hasRun.current = true;
 
       if (user) {
-        router.push("/");
+        // 저장된 리다이렉트 경로 확인
+        const redirectPath = sessionStorage.getItem("redirectAfterLogin");
+        if (redirectPath) {
+          sessionStorage.removeItem("redirectAfterLogin");
+          router.push(redirectPath);
+        } else {
+          router.push("/home");
+        }
       } else {
         router.push(`/error?message=${encodeURIComponent(t("failMessage"))}`);
       }


### PR DESCRIPTION
## Title  
feat: enhance auth flow with sessionStorage redirect and smarter logout handling

## Purpose
- Login flow needed a way to restore the previous page after authentication, but the path was not preserved.
- Logout behavior was not context-aware, as it always forced a redirect.
- Callback handling required refinement to restore saved paths and update the default route.
- These improvements make authentication flow more consistent, user-friendly, and predictable.

## Changes
### useAuth.ts
- Store current page path in `sessionStorage` during login for post-login redirect
- Add smart logout logic:
  - Redirect to home if logging out from protected pages (e.g., `/mypage`)
  - Otherwise refresh the current page

### CallbackClient.tsx
- Restore saved redirect path after login callback if available
- Update default redirect from `/` to `/home`
- Clear sessionStorage after use to prevent stale redirects