### PR TITLE
fix: gate session checks with requireAuth to stop initial 401s

### DIFF
--- a/src/lib/hooks/auth/useAuth.ts
+++ b/src/lib/hooks/auth/useAuth.ts
@@ -9,7 +9,7 @@ export const useAuth = (requireAuth: boolean = false) => {
   const { user, setUser, clearUser } = useAuthStore();
   const queryClient = useQueryClient();
 
-  // 세션 조회
+  // 세션 조회 - 인증이 필요한 페이지에서만 실행
   const {
     data: sessionUser,
     isLoading,
@@ -23,7 +23,8 @@ export const useAuth = (requireAuth: boolean = false) => {
       }
       return null;
     },
-    refetchOnWindowFocus: true // 인증은 포커스 시 체크 필요
+    enabled: requireAuth, // 인증이 필요한 경우에만 세션 체크
+    refetchOnWindowFocus: requireAuth // 인증이 필요한 경우에만 포커스 시 체크
     // 나머지는 전역 설정 사용 (5분 staleTime, 15분 gcTime)
   });
 


### PR DESCRIPTION
## Title  
fix: gate session checks with requireAuth to stop initial 401s

## Purpose  
- Initial page loads were triggering session requests globally, causing unnecessary 401 errors in the console.  
- Authentication should only be verified when a page actually requires it.  
- The session query is now conditionally enabled to eliminate noisy 401s and reduce redundant network calls.

## Changes  
- Updated `useAuth.ts` to check session **only** when `requireAuth` is `true`  
- Set `enabled: requireAuth` on the session query to prevent global fetches  
- Set `refetchOnWindowFocus: requireAuth` so focus-based revalidation runs only on protected pages  
- Kept global cache policy as-is (e.g., 5m `staleTime`, 15m `gcTime`) and applied it through query defaults  
- Default behavior: `useAuth()` uses `requireAuth: false`, so public pages no longer request session data

## Optional  
- Usage on protected routes: `useAuth({ requireAuth: true })`  
- This change reduces console noise and avoids unnecessary 401s without altering protected-page behavior