### PR TITLE
fix: update i18n locale handling for Next.js 15 async request pattern

### DIFF
--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,15 +1,13 @@
 import { getRequestConfig } from "next-intl/server";
-import { headers } from "next/headers";
 
+export default getRequestConfig(async ({ requestLocale }) => {
+  // Next.js 15 방식: requestLocale 사용
+  let locale = await requestLocale;
 
-export default getRequestConfig(async () => {
-  // 미들웨어에서 전달받은 URL 쿼리 파라미터 사용
-  const headersList = await headers();
-  const search = headersList.get('x-search') || '';
-
-  // lang 파라미터 추출
-  const urlParams = new URLSearchParams(search);
-  const locale = (urlParams.get('lang') || "en") as "ko" | "en";
+  // 기본값 및 유효성 검사
+  if (!locale || !["ko", "en"].includes(locale)) {
+    locale = "en";
+  }
 
   // 로컬 JSON 파일에서 번역 데이터 로드
   const messages = (await import(`../../locale/${locale}.json`)).default;


### PR DESCRIPTION
## Title
fix: update i18n locale handling for Next.js 15 async request pattern

## Purpose
- After upgrading to Next.js 15, the `headers()` function became asynchronous and the old approach no longer worked.
- `next-intl` introduced the `requestLocale` parameter for compatibility, while the legacy `locale` parameter is now deprecated.
- This change updates the i18n logic to follow the new async pattern, ensuring compatibility with Next.js 15 and resolving locale-related errors.

## Changes
- Updated parameter from `()` → `({ requestLocale })`
- Changed locale retrieval from direct `headers()` call → `await requestLocale`
- Applied the new asynchronous request pattern introduced in Next.js 15
- Fixed errors related to `headers()` and aligned with the latest `next-intl` recommendation