### PR TITLE
fix: revert to query-based language routing with 'lang' parameter

### DIFF
--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,16 +1,20 @@
 import { getRequestConfig } from "next-intl/server";
-import { hasLocale } from "next-intl";
-import { routing } from "./routing";
+import { headers } from "next/headers";
 
-export default getRequestConfig(async ({ requestLocale }) => {
-  // requestLocale을 기다리고 유효성 검사
-  const requested = await requestLocale;
-  const locale = hasLocale(routing.locales, requested)
-    ? requested
-    : routing.defaultLocale;
+export default getRequestConfig(async () => {
+  // 미들웨어에서 전달받은 URL 쿼리 파라미터 사용
+  const headersList = await headers();
+  const search = headersList.get("x-search") || "";
+
+  // lang 파라미터 추출
+  const urlParams = new URLSearchParams(search);
+  const locale = (urlParams.get("lang") || "en") as "ko" | "en";
+
+  // 로컬 JSON 파일에서 번역 데이터 로드
+  const messages = (await import(`../../locale/${locale}.json`)).default;
 
   return {
     locale,
-    messages: (await import(`../../locale/${locale}.json`)).default
+    messages
   };
 });

--- a/src/lib/store/languageStore.ts
+++ b/src/lib/store/languageStore.ts
@@ -15,16 +15,10 @@ const getInitialLanguage = (): Locale => {
 
   // get language from URL params
   const urlParams = new URLSearchParams(window.location.search);
-  const localeParam = urlParams.get("locale");
-
-  console.log("Language store - URL params:", window.location.search);
-  console.log("Language store - locale param:", localeParam);
+  const langParam = urlParams.get("lang");
 
   // use URL param, if not, use default 'en'
-  const result = (localeParam === "ko" || localeParam === "en") ? localeParam : "en";
-  console.log("Language store - final language:", result);
-
-  return result;
+  return (langParam as Locale) || "en";
 };
 
 // locale param for backend API calls

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,18 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 
 export function middleware(request: NextRequest) {
-  // URL 쿼리 파라미터에서 언어 감지 (?locale=ko)
-  const localeParam = request.nextUrl.searchParams.get("locale");
-  const locale = (localeParam === "ko" || localeParam === "en") ? localeParam : "en";
-
-  // next-intl이 사용할 헤더 설정
+  // i18n에서 필요한 쿼리 파라미터만 헤더에 전달
   const requestHeaders = new Headers(request.headers);
-  requestHeaders.set("x-next-intl-locale", locale);
   requestHeaders.set("x-search", request.nextUrl.search);
-
-  console.log("Middleware - URL:", request.nextUrl.href);
-  console.log("Middleware - locale param:", localeParam);
-  console.log("Middleware - final locale:", locale);
 
   return NextResponse.next({
     request: {


### PR DESCRIPTION
## Title  
fix: revert to query-based language routing with 'lang' parameter

## Purpose  
- In production, language detection was always defaulting to Korean.  
- Initially suspected to be caused by the async change in Next.js 15 `headers()`, but the actual root cause was a **misconfiguration in the admin panel where language values were not properly set**.  
- To resolve this, the implementation was reverted back to the previously stable query-based routing using the `lang` parameter.

## Changes  
- Reverted locale handling from `requestLocale` back to query parameter `lang`  
- Removed unnecessary Next.js 15–specific locale handling logic  
- Restored the logic used in #63 which was working correctly before  
- Ensured consistent language detection across both development and production environments