### PR TITLE
fix: prevent unintended clearUser on refresh by refining session check logic

### DIFF
--- a/src/lib/hooks/auth/useAuth.ts
+++ b/src/lib/hooks/auth/useAuth.ts
@@ -21,8 +21,7 @@ export const useAuth = (requireAuth: boolean = false) => {
   // 세션 조회 - 쿠키가 있거나 auth callback이거나 localStorage에 user가 있을 때 API 호출
   const {
     data: sessionUser,
-    isLoading,
-    error
+    isLoading
   } = useQuery({
     queryKey: ["auth", "session"],
     queryFn: async () => {


### PR DESCRIPTION
## Title  
fix: prevent unintended clearUser on refresh by refining session check logic

## Purpose  
- On page refresh, the condition `!isLoading && !sessionUser` always evaluated to true, which caused `clearUser()` to be triggered.  
- As a result, valid user information stored in localStorage was being cleared even though the session was still valid.  
- The logic was updated to only clear user data when localStorage has a user but both cookie and session are missing.  
- This ensures that localStorage data persists on refresh and logout only occurs when the session is actually expired.  

## Changes  
- Updated session check logic in auth flow  
- Modified `clearUser()` trigger condition to require missing cookie + session alongside existing localStorage user  
- Prevented localStorage reset on null session API responses  