### PR TITLE
refactor: enhance HeroSection layout and MainHero component for improved responsiveness

### DIFF
--- a/src/app/home/_components/section/hero/BackgroundImage.tsx
+++ b/src/app/home/_components/section/hero/BackgroundImage.tsx
@@ -12,7 +12,7 @@ const BackgroundImage = ({ blurDataURL }: BackgroundImageProps) => {
         src={background}
         alt="Hero background"
         priority
-        className="h-full w-full object-cover"
+        className="h-full w-full object-cover object-center"
         quality={80}
         sizes="100vw"
         fill

--- a/src/app/home/_components/section/hero/HeroSection.tsx
+++ b/src/app/home/_components/section/hero/HeroSection.tsx
@@ -7,10 +7,16 @@ type HeroSectionProps = {
 
 const HeroSection = ({ backgroundBlur }: HeroSectionProps) => {
   return (
-    <section aria-labelledby="hero-title" className="relative h-[1080px] w-full">
-      <BackgroundImage blurDataURL={backgroundBlur} />
-      <div className="relative z-10 mx-auto h-full w-full max-w-[1200px] px-16 py-40">
-        <MainHero />
+    <section
+      aria-labelledby="hero-title"
+      className="relative w-full"
+      style={{ "--hero-h": "clamp(480px, 70svh, 800px)" } as React.CSSProperties}
+    >
+      <div className="relative" style={{ minHeight: "var(--hero-h)" }}>
+        <BackgroundImage blurDataURL={backgroundBlur} />
+        <div className="relative z-10 mx-auto flex h-full w-full max-w-[1200px] items-center px-3 py-6 xs:px-4 xs:py-8 sm:px-6 sm:py-10 mb:px-8 mb:py-12 tb:px-8 tb:py-16 lt:px-16 lt:py-20">
+          <MainHero />
+        </div>
       </div>
     </section>
   );

--- a/src/app/home/_components/section/hero/MainHero.tsx
+++ b/src/app/home/_components/section/hero/MainHero.tsx
@@ -25,21 +25,61 @@ const MainHero = () => {
   return (
     <section
       aria-labelledby="hero-title"
-      className="shadow-emphasize flex items-center justify-center gap-16 rounded-[1rem] bg-[#F4EBDC]/80 px-16 py-16"
+      aria-describedby="hero-subtitle"
+      className="shadow-emphasize w-full rounded-2xl bg-[#F4EBDC]/80 p-4 xs:p-5 sm:p-6 mb:p-8 tb:p-12 xl:p-16"
     >
-      <div className="flex w-full flex-col items-start gap-20">
-        <div className="flex w-full flex-col items-start gap-12">
-          <h1 id="hero-title" className="w-full whitespace-pre-line text-heading text-primary-default">
-            {t("title")}
-          </h1>
-          <p className="whitespace-pre-line text-subtitle2 text-primary-default">{t("subtitle")}</p>
+      <div className="flex flex-col items-center gap-4 xs:gap-5 sm:gap-6">
+        {/* Text | Image area */}
+        <div className="flex w-full flex-col items-center gap-4 xs:gap-5 sm:gap-6 mb:flex-row mb:items-center mb:justify-between mb:gap-8">
+          <div className="flex w-full flex-col items-center gap-3 xs:gap-4 sm:gap-4 mb:items-start">
+            <h1
+              id="hero-title"
+              className="w-full whitespace-pre-line text-center text-body1 font-bold text-primary-default xs:text-title1 sm:text-subHeading mb:text-left tb:text-heading"
+            >
+              {t("title")}
+            </h1>
+            <p
+              id="hero-subtitle"
+              className="whitespace-pre-line text-center text-caption leading-relaxed text-primary-default xs:text-body1 sm:text-subtitle mb:text-left"
+            >
+              {t("subtitle")}
+            </p>
+
+            <figure
+              className="shadow-normal relative flex flex-shrink-0 items-center justify-center overflow-hidden rounded-full bg-bg-01 mb:hidden"
+              style={{ width: "clamp(80px, 20vw, 128px)", height: "clamp(80px, 20vw, 128px)" }}
+            >
+              <Image
+                src={plant}
+                alt="Plant illustration"
+                fill
+                className="object-contain"
+                sizes="(max-width: 480px) 80px, 128px"
+                priority
+              />
+              <figcaption className="sr-only">{t("title")}</figcaption>
+            </figure>
+          </div>
+
+          <figure className="shadow-normal relative hidden flex-shrink-0 items-center justify-center overflow-hidden rounded-full bg-bg-01 mb:flex mb:size-32 tb:size-40 lt:size-48 xl:size-60">
+            <Image
+              src={plant}
+              alt="Plant illustration"
+              fill
+              className="object-contain"
+              sizes="(min-width:1200px) 240px, (min-width:1024px) 192px, (min-width:768px) 160px, (min-width:480px) 128px, 128px"
+              priority
+            />
+            <figcaption className="sr-only">{t("title")}</figcaption>
+          </figure>
         </div>
 
-        <div className="flex w-full flex-row items-start gap-4">
+        {/* Desktop button */}
+        <div className="hidden w-full flex-row items-start justify-start gap-4 mb:flex">
           <Button
             variant="primary"
             size="md"
-            className="flex items-center justify-center px-8 py-3"
+            className="flex items-center justify-center px-6 py-3 text-caption tb:px-8 tb:text-body1"
             onClick={handleFirstButtonClick}
           >
             {isLoggedIn ? t("storeButton") : t("startButton")}
@@ -47,18 +87,34 @@ const MainHero = () => {
           <Button
             variant="primaryLine"
             size="md"
-            className="flex items-center justify-center px-8 py-3"
+            className="flex items-center justify-center px-6 py-3 text-caption tb:px-8 tb:text-body1"
+            onClick={() => router.push("/mypage")}
+          >
+            {t("myPageButton")}
+          </Button>
+        </div>
+
+        {/* Mobile button */}
+        <div className="flex w-full flex-col items-center justify-center gap-2 xs:gap-3 sm:gap-3 mb:hidden">
+          <Button
+            variant="primary"
+            size="md"
+            className="w-full max-w-[200px] px-6 text-caption"
+            onClick={handleFirstButtonClick}
+          >
+            {isLoggedIn ? t("storeButton") : t("startButton")}
+          </Button>
+
+          <Button
+            variant="primaryLine"
+            size="md"
+            className="w-full max-w-[200px] px-6 text-caption"
             onClick={() => router.push("/mypage")}
           >
             {t("myPageButton")}
           </Button>
         </div>
       </div>
-
-      <figure className="shadow-normal flex h-60 w-60 flex-shrink-0 items-center justify-center overflow-hidden rounded-full bg-bg-01">
-        <Image src={plant} alt="Plant illustration" width={200} height={200} className="object-contain" />
-        <figcaption className="sr-only">{t("title")}</figcaption>
-      </figure>
     </section>
   );
 };


### PR DESCRIPTION
## Title
refactor: enhance HeroSection layout and MainHero component for improved responsiveness

## Purpose
The hero section was following a desktop-first layout and lacked the detailed responsive patterns already applied in the header and CTA sections.
This update improves consistency across breakpoints by introducing CSS variables, progressive typography, and viewport-specific adjustments for layout, padding, and images.

## Changes
### HeroSection
- Applied CSS variable `--hero-h: clamp(480px, 70svh, 800px)` for dynamic height
- Updated responsive padding with fine-grained breakpoints
- Improved flexbox centering for better alignment

### MainHero
- Adjusted layout: desktop horizontal → mobile vertical (consistent with CTA pattern)
- Added progressive padding (`p-4` → `xl:p-16`)
- Enhanced typography scaling from body text to subheading
- Added mobile-specific image with clamp-based sizing
- Split buttons for desktop (`hidden mb:flex`) and mobile (`flex mb:hidden`)

### BackgroundImage
- Improved positioning with `object-center` for consistent visual alignment