### PR TITLE
chore: adjust header and footer layout sizing

### DIFF
--- a/src/components/layout/FooterContent.tsx
+++ b/src/components/layout/FooterContent.tsx
@@ -10,13 +10,10 @@ const FooterContent = () => {
   return (
     <footer className="flex w-full items-center bg-gray-700">
       {/* Mobile Footer */}
-      <section
-        className="mx-auto flex w-full items-center justify-between px-3 xs:px-4 sm:px-6 tb:hidden"
-        style={{ height: "clamp(60px, 12vh, 80px)" }}
-      >
+      <section className="mx-auto flex h-[clamp(80px,12vh,96px)] w-full items-center justify-between px-3 xs:px-4 sm:px-6 tb:hidden">
         {/* Logo */}
         <div className="flex items-center gap-2 xs:gap-3 sm:gap-4">
-          <h2 className="text-small font-medium text-text-01 xs:text-body1 sm:text-title2">Git-Plants</h2>
+          <h2 className="text-caption text-text-01 xs:text-body1 sm:text-subtitle">Git-Plants</h2>
           <span className="text-mini text-text-02 xs:text-small sm:text-caption">© 2025</span>
         </div>
 
@@ -25,38 +22,28 @@ const FooterContent = () => {
           href="https://github.com/reizvoll/git-plants-frontend"
           target="_blank"
           rel="noopener noreferrer"
-          className="flex items-center rounded-lg bg-gray-600 transition-colors hover:bg-gray-500 gap-1.5 xs:gap-2 sm:gap-2 px-2 py-1.5 xs:px-3 xs:py-2 sm:px-4 sm:py-2.5"
+          className="flex items-center gap-1.5 rounded-lg bg-gray-600 px-2 py-1.5 transition-colors hover:bg-gray-500 xs:gap-2 xs:px-3 xs:py-2 sm:gap-2 sm:px-4 sm:py-2.5"
         >
-          <GithubIcon
-            className="text-text-01 w-3.5 h-3.5 xs:w-4 xs:h-4 sm:w-5 sm:h-5"
-            width={16}
-            height={16}
-          />
-          <span className="whitespace-nowrap text-mini font-medium text-text-01 xs:text-small sm:text-caption">Repository</span>
+          <GithubIcon className="h-3.5 w-3.5 text-text-01 xs:h-4 xs:w-4 sm:h-5 sm:w-5" width={16} height={16} />
+          <span className="whitespace-nowrap text-mini font-medium text-text-01 xs:text-small sm:text-caption">
+            Repository
+          </span>
         </Link>
       </section>
 
       {/* Desktop Footer */}
-      <section
-        className="mx-auto hidden w-full max-w-full flex-col items-start justify-center px-4 tb:flex tb:max-w-[75rem] tb:px-8 tb:py-8 lt:py-12 gap-6 tb:gap-8 min-h-[120px] tb:min-h-[160px] lt:min-h-[208px]"
-      >
+      <section className="mx-auto hidden min-h-[120px] w-full max-w-full flex-col items-start justify-center gap-6 px-4 tb:flex tb:min-h-[160px] tb:max-w-[75rem] tb:gap-8 tb:px-8 tb:py-8 lt:min-h-[208px] lt:py-12">
         <header className="flex items-center gap-4 tb:gap-6">
           <h2 id="site-footer-title" className="text-title1 text-text-04 tb:text-subHeading">
             Git-Plants
           </h2>
           <Link href="https://github.com/reizvoll/git-plants-frontend" target="_blank" rel="noopener noreferrer">
-            <GithubIcon
-              className="text-text-04 w-6 h-6 tb:w-7 tb:h-7"
-              width={24}
-              height={24}
-            />
+            <GithubIcon className="h-6 w-6 text-text-04 tb:h-7 tb:w-7" width={24} height={24} />
           </Link>
         </header>
 
-        <address className="flex flex-col items-start not-italic gap-4 tb:gap-6">
-          <p
-            className="font-pretendard text-caption font-medium text-text-01 tb:text-body1 leading-relaxed"
-          >
+        <address className="flex flex-col items-start gap-4 not-italic tb:gap-6">
+          <p className="font-pretendard text-caption font-medium leading-relaxed text-text-01 tb:text-body1">
             {t("description")}
             <br />
             {t("feedback")}

--- a/src/components/layout/HeaderContent.tsx
+++ b/src/components/layout/HeaderContent.tsx
@@ -142,10 +142,8 @@ const HeaderContent = () => {
         <div className="flex items-center gap-2 xs:gap-2.5 sm:gap-3 tb:hidden">
           {/* GitHub Login Button (only if not logged in) */}
           {!user && (
-            <Button
-              variant="gray"
-              size="sm"
-              className="flex aspect-square items-center justify-center rounded-lg bg-gray-800 p-2 xs:p-2.5 sm:p-3"
+            <button
+              className="flex h-10 w-10 items-center justify-center rounded-lg bg-gray-800 hover:bg-gray-700"
               onClick={login}
               aria-label="Sign in GitHub"
             >
@@ -155,7 +153,7 @@ const HeaderContent = () => {
                 className="text-text-01 xs:h-4 xs:w-4 sm:h-4 sm:w-4"
                 aria-hidden="true"
               />
-            </Button>
+            </button>
           )}
 
           {/* User Profile (if logged in) */}


### PR DESCRIPTION
## Title
chore: adjust header and footer layout sizing

## Purpose
- The header shows visual misalignment between the hamburger menu button and the GitHub login button.
- This is caused by inconsistent sizing when using the `Button` component for the login button.
- Switching to a native `button` element matches the menu button size.
- Additionally adjusting footer height and internal logo text size improves overall layout consistency.

## Changes
### Header
- Replaced `Button` component with native `button` element for GitHub login to match menu button size

### Footer
- Increased footer height for better spacing
- Adjusted internal logo text size for visual balance