### PR TITLE
fix: resolve image aspect ratio issue on mobile in RewardSectionCard

### DIFF
--- a/src/app/home/_components/section/feature/RewardSectionCard.tsx
+++ b/src/app/home/_components/section/feature/RewardSectionCard.tsx
@@ -17,7 +17,7 @@ const RewardSectionCard = () => {
       </h3>
 
       <figure className="h-auto w-[80px] xs:w-[110px] sm:w-[140px]">
-        <Image src={sysflow} alt="System flow illustration" loading="lazy" className="h-full w-auto" />
+        <Image src={sysflow} alt="System flow illustration" loading="lazy" className="h-auto w-full" />
         <figcaption className="sr-only">{t("title")}</figcaption>
       </figure>
 


### PR DESCRIPTION
## Title
fix: resolve image aspect ratio issue on mobile in RewardSectionCard

## Purpose
- Image aspect ratio was breaking on mobile devices due to conflicting height/width constraints.
- The root cause was applying `h-full` to the image while the parent container had `h-auto`, resulting in undefined height behavior.
- This fix ensures the image scales properly based on parent width while maintaining its original aspect ratio.

## Changes
- Changed image sizing approach from `h-full w-auto` to `h-auto w-full`
- Image now scales based on parent container width with preserved aspect ratio